### PR TITLE
Fixes #1. Make tables display properly again.

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -13,3 +13,8 @@ nav[role=toc] li.active > a {
 .bs-docs-sidenav li ul {
   padding-left: 20px;
 }
+
+/* Fix table conflict with bootstrap's row class */
+.table .row {
+  display: table-row;
+}


### PR DESCRIPTION
Bootstrap uses the class 'row' for part of its grid layout, but the HTML5 output uses the row class as well. 

This commit fixes that collision and makes tables display properly again.