### PR TITLE
Bootstrap Figure support

### DIFF
--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -133,7 +133,9 @@
       <xsl:call-template name="setscale"/>
       <xsl:call-template name="setidaname"/>
       <!--xsl:call-template name="place-fig-lbl"/-->
-      <xsl:apply-templates select="node() except *[contains(@class, ' topic/title ') or contains(@class, ' topic/desc ')]"/>
+      <xsl:apply-templates
+        select="node() except *[contains(@class, ' topic/title ') or contains(@class, ' topic/desc ')]"
+      />
       <!-- ↓ Move Figure title below image ↑ -->
       <xsl:call-template name="place-fig-lbl"/>
       <!-- ↑ End customization · Continue with DITA-OT defaults ↓ -->
@@ -148,7 +150,10 @@
   <xsl:template name="place-fig-lbl">
     <xsl:param name="stringName"/>
     <!-- Number of fig/title's including this one -->
-    <xsl:variable name="fig-count-actual" select="count(preceding::*[contains(@class, ' topic/fig ')]/*[contains(@class, ' topic/title ')])+1"/>
+    <xsl:variable
+      name="fig-count-actual"
+      select="count(preceding::*[contains(@class, ' topic/fig ')]/*[contains(@class, ' topic/title ')])+1"
+    />
     <xsl:variable name="ancestorlang">
       <xsl:call-template name="getLowerCaseLang"/>
     </xsl:variable>
@@ -159,7 +164,10 @@
           <!-- ↑ Start customization · Add Bootstrap class ↓ -->
           <xsl:variable name="fig-caption-class" select="concat('figure-caption ', $BOOTSTRAP_CSS_FIGURE_CAPTION)"/>
           <xsl:apply-templates select="." mode="set-output-class">
-            <xsl:with-param name="default" select="concat($fig-caption-class, ./*[contains(@class, ' topic/title ')][1]/@outputclass)"/>
+            <xsl:with-param
+              name="default"
+              select="concat($fig-caption-class, ./*[contains(@class, ' topic/title ')][1]/@outputclass)"
+            />
           </xsl:apply-templates>
           <!-- ↑ End customization · Continue with DITA-OT defaults ↓ -->
           <span class="fig--title-label">
@@ -214,7 +222,7 @@
     </xsl:variable>
     <figure>
       <xsl:if test="$default-fig-class != ''">
-        <xsl:attribute name="class" >
+        <xsl:attribute name="class">
           <xsl:value-of select="$default-fig-class"/>
           <xsl:text> figure </xsl:text>
           <xsl:value-of select="$BOOTSTRAP_CSS_FIGURE"/>
@@ -241,7 +249,7 @@
     </xsl:variable>
     <figure>
       <xsl:if test="$default-fig-class != ''">
-        <xsl:attribute name="class" >
+        <xsl:attribute name="class">
           <xsl:value-of select="$default-fig-class"/>
           <xsl:text> figure </xsl:text>
           <xsl:value-of select="$BOOTSTRAP_CSS_FIGURE"/>
@@ -265,7 +273,7 @@
       <xsl:when test="@frame = 'top'">border-top</xsl:when>
       <xsl:when test="@frame = 'bottom'">border-bottom</xsl:when>
       <xsl:when test="@frame = 'topbot'">border-top border-bottom</xsl:when>
-      <xsl:otherwise></xsl:otherwise>
+      <xsl:otherwise/>
     </xsl:choose>
   </xsl:template>
 </xsl:stylesheet>

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -11,6 +11,13 @@
   version="2.0"
   exclude-result-prefixes="xs dita-ot dita2html"
 >
+
+  <!-- Define a newline character -->
+  <xsl:variable name="newline">
+<xsl:text>
+</xsl:text>
+  </xsl:variable>
+
   <!-- Override to add Bootstrap classes and roles -->
   <xsl:template name="commonattributes">
     <xsl:param name="default-output-class"/>

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -72,7 +72,8 @@
     </xsl:choose>
   </xsl:template>
 
-  <!-- Override  Notes to add Bootstrap classes and roles -->
+  <!-- Override to add Bootstrap Alert classes and roles to Note elements -->
+  <!-- https://getbootstrap.com/docs/5.1/components/alerts/ -->
   <xsl:template match="*" mode="process.note.common-processing">
     <xsl:param name="type" select="@type"/>
     <xsl:param name="title">
@@ -117,7 +118,8 @@
     </div>
   </xsl:template>
 
-  <!-- =========== FIGURE =========== -->
+  <!-- Customization to add Bootstrap Figure Content -->
+  <!-- https://getbootstrap.com/docs/5.1/content/figures/ -->
   <xsl:template match="*[contains(@class, ' topic/fig ')]" name="topic.fig">
     <xsl:variable name="default-fig-class">
       <xsl:apply-templates select="." mode="dita2html:get-default-fig-class"/>
@@ -215,7 +217,8 @@
   </xsl:template>
 
 
-    <!-- PRE -->
+  <!-- Customization to add Bootstrap Borders to Codeblock elements-->
+  <!-- https://getbootstrap.com/docs/5.1/utilities/borders/ -->
   <xsl:template match="*[contains(@class, ' topic/pre ') and @frame]">
     <xsl:variable name="default-fig-class">
       <xsl:apply-templates select="." mode="dita2html:get-default-fig-class"/>
@@ -242,7 +245,8 @@
 
   </xsl:template>
 
-  <!-- lines - body font -->
+  <!-- Customization to add Bootstrap Borders to Lines elements-->
+  <!-- https://getbootstrap.com/docs/5.1/utilities/borders/ -->
   <xsl:template match="*[contains(@class, ' topic/lines ') and @frame]">
     <xsl:variable name="default-fig-class">
       <xsl:apply-templates select="." mode="dita2html:get-default-fig-class"/>

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -206,6 +206,57 @@
     </xsl:choose>
   </xsl:template>
 
+
+    <!-- PRE -->
+  <xsl:template match="*[contains(@class, ' topic/pre ') and @frame]">
+    <xsl:variable name="default-fig-class">
+      <xsl:apply-templates select="." mode="dita2html:get-default-fig-class"/>
+    </xsl:variable>
+    <figure>
+      <xsl:if test="$default-fig-class != ''">
+        <xsl:attribute name="class" >
+          <xsl:value-of select="$default-fig-class"/>
+          <xsl:text> figure </xsl:text>
+          <xsl:value-of select="$BOOTSTRAP_CSS_FIGURE"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
+      <xsl:call-template name="spec-title-nospace"/>
+      <pre>
+        <xsl:attribute name="class" select="name()"/>
+        <xsl:call-template name="commonattributes"/>
+        <xsl:call-template name="setscale"/>
+        <xsl:call-template name="setidaname"/>
+        <xsl:apply-templates/>
+      </pre>
+      <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
+    </figure>
+
+  </xsl:template>
+
+  <!-- lines - body font -->
+  <xsl:template match="*[contains(@class, ' topic/lines ') and @frame]">
+    <xsl:variable name="default-fig-class">
+      <xsl:apply-templates select="." mode="dita2html:get-default-fig-class"/>
+    </xsl:variable>
+    <figure>
+      <xsl:if test="$default-fig-class != ''">
+        <xsl:attribute name="class" >
+          <xsl:value-of select="$default-fig-class"/>
+          <xsl:text> figure </xsl:text>
+          <xsl:value-of select="$BOOTSTRAP_CSS_FIGURE"/>
+        </xsl:attribute>
+      </xsl:if>
+      <xsl:call-template name="spec-title-nospace"/>
+      <p>
+        <xsl:call-template name="commonattributes"/>
+        <xsl:call-template name="setscale"/>
+        <xsl:call-template name="setidaname"/>
+        <xsl:apply-templates/>
+      </p>
+    </figure>
+  </xsl:template>
+
   <!-- Determine the default Bootstrap class attribute for a figure -->
   <xsl:template match="*" mode="dita2html:get-default-fig-class">
     <xsl:choose>

--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -19,6 +19,10 @@
   <xsl:param name="BOOTSTRAP_CSS_TABS" select="''"/>
   <xsl:param name="BOOTSTRAP_CSS_TABS_VERTICAL" select="'me-3'"/>
   <xsl:param name="BOOTSTRAP_CSS_ACCORDION" select="''"/>
+  <xsl:param name="BOOTSTRAP_CSS_FIGURE" select="' w-100 mw-100 p-3 '"/>
+  <xsl:param name="BOOTSTRAP_CSS_FIGURE_CAPTION" select="''"/>
+  <xsl:param name="BOOTSTRAP_CSS_FIGURE_IMAGE" select="'img-fluid border rounded'"/>
+
   <!-- Add a Bootstrap CSS border to codeblocks -->
   <xsl:template match="*[contains(@class, ' topic/pre ')]" mode="get-output-class">
     <xsl:value-of select="$BOOTSTRAP_CSS_CODEBLOCK"/>
@@ -93,6 +97,12 @@
     <xsl:value-of select="BOOTSTRAP_CSS_ACCORDION"/>
   </xsl:template>
 
+  <!-- Change the default Bootstrap CSS text color of the figure captions -->
+  <xsl:template match="*[contains(@class, ' topic/figcaption ')]" mode="get-output-class">
+    <xsl:text>figure-caption </xsl:text>
+    <xsl:value-of select="$BOOTSTRAP_CSS_FIGURE_CAPTION"/>
+  </xsl:template>
+
   <!-- Add additional Bootstrap CSS classes based on outputclass -->
   <xsl:template name="bootstrap-class">
     <xsl:choose>
@@ -116,6 +126,14 @@
       </xsl:when>
       <xsl:when test="contains(@outputclass, 'alert-')">
         <xsl:text>alert</xsl:text>
+      </xsl:when>
+      <xsl:when test="contains(@class, ' topic/fig ')">
+        <xsl:text> figure </xsl:text>
+        <xsl:value-of select="$BOOTSTRAP_CSS_FIGURE"/>
+      </xsl:when>
+      <xsl:when test="contains(@class, ' topic/image ') and ancestor::*[contains(@class, ' topic/fig ')]">
+        <xsl:text> figure-img </xsl:text>
+        <xsl:value-of select="$BOOTSTRAP_CSS_FIGURE_IMAGE"/>
       </xsl:when>
       <xsl:when test="contains(@outputclass, 'carousel-')">
         <xsl:text>carousel</xsl:text>

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ The HTML output for the following DITA elements can be annotated with common Boo
 - `bootstrap.css.tabs` – common utility classes for Bootstrap tabbed dialog components
 - `bootstrap.css.tabs.vertical` – common utility classes for Bootstrap vertical tabbed dialog components
 - `bootstrap.css.accordion` – common utility classes for Bootstrap accordion components
+- `bootstrap.css.figure` – common utility classes for DITA `<fig>` elements
+- `bootstrap.css.figure.caption` – common utility classes for DITA `<title>` elements within `<fig>` elements
+- `bootstrap.css.figure.image` – common utility classes for for DITA `<image>` elements within `<fig>` elements
+
 
 You can add your own XSLT customizations by creating a new plug-in that extends the DITA Bootstrap XSLT transforms. Just amend `args.xsl` to point to your own XSLT files. An [XSLT template][12] is included within this repository.
 

--- a/insertParameters.xml
+++ b/insertParameters.xml
@@ -54,4 +54,16 @@
     expression="${bootstrap.css.accordion}"
     if:set="bootstrap.css.accordion"
   />
+  <param
+    name="BOOTSTRAP_CSS_FIGURE"
+    expression="${bootstrap.css.figure}"
+    if:set="bootstrap.css.figure"/>
+  <param
+    name="BOOTSTRAP_CSS_FIGURE_CAPTION"
+    expression="${bootstrap.css.figure.caption}"
+    if:set="bootstrap.css.figure.caption"/>
+  <param
+    name="BOOTSTRAP_CSS_FIGURE_IMAGE"
+    expression="${bootstrap.css.figure.image}"
+    if:set="bootstrap.css.figure.image"/>
 </dummy>

--- a/insertParameters.xml
+++ b/insertParameters.xml
@@ -57,13 +57,16 @@
   <param
     name="BOOTSTRAP_CSS_FIGURE"
     expression="${bootstrap.css.figure}"
-    if:set="bootstrap.css.figure"/>
+    if:set="bootstrap.css.figure"
+  />
   <param
     name="BOOTSTRAP_CSS_FIGURE_CAPTION"
     expression="${bootstrap.css.figure.caption}"
-    if:set="bootstrap.css.figure.caption"/>
+    if:set="bootstrap.css.figure.caption"
+  />
   <param
     name="BOOTSTRAP_CSS_FIGURE_IMAGE"
     expression="${bootstrap.css.figure.image}"
-    if:set="bootstrap.css.figure.image"/>
+    if:set="bootstrap.css.figure.image"
+  />
 </dummy>

--- a/plugin.xml
+++ b/plugin.xml
@@ -84,6 +84,21 @@
       type="string"
       desc="Bootstrap classes for flush accordion components"
     />
+    <param
+      name="bootstrap.css.figure"
+      type="string"
+      desc="Bootstrap classes for figures"
+    />
+    <param
+      name="bootstrap.css.figure.caption"
+      type="string"
+      desc="Bootstrap classes for figure captions"
+    />
+    <param
+      name="bootstrap.css.figure.image"
+      type="string"
+      desc="Bootstrap classes for figure images"
+    />
   </transtype>
   <feature extension="ant.import" file="build_dita2html5-bootstrap.xml"/>
   <feature extension="extend.css.process" value="dita-bootstrap.css.copy"/>

--- a/sample/document.ditamap
+++ b/sample/document.ditamap
@@ -25,6 +25,7 @@
     </topicmeta>
     <topicref navtitle="Images" format="dita" type="topic" href="images.dita"/>
     <topicref navtitle="Tables" format="dita" type="topic" href="tables.dita"/>
+    <topicref navtitle="Figures" format="dita" type="topic" href="figures.dita"/>
   </chapter>
   <chapter>
     <topicmeta>

--- a/sample/figures.dita
+++ b/sample/figures.dita
@@ -102,6 +102,5 @@
   ...
 &lt;/fig&gt;
     </codeblock>
-
   </body>
 </topic>

--- a/sample/figures.dita
+++ b/sample/figures.dita
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<!-- Within the sample documentation, where necessary, the texts describing the
+   usage of each component have been copied directly from the official Bootstrap
+   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   markup is used throughout the examples describing how to implement these
+   components correctly using outputclass. -->
+<topic id="figures">
+  <title>Figures</title>
+  <abstract>
+    <shortdesc>Documentation and examples for displaying related images and text with the figure component in Bootstrap.</shortdesc>
+    <p>Anytime you need to display a piece of content—like an image with an optional caption, consider
+     using a DITA <xmlelement>fig</xmlelement> element. Bootstrap CSS classes <xmlatt>class="figure"</xmlatt> ,
+     <xmlatt>class="figure-img"</xmlatt> and <xmlatt>class="figure-caption"</xmlatt> are
+     automatically included to the output to provide some baseline styles for the HTML5 <xmlelement>figure</xmlelement> and <xmlelement>figcaption</xmlelement> elements.
+    </p>
+  </abstract>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>Figure</indexterm>
+        <indexterm>CSS
+          <indexterm><xmlatt>outputclass</xmlatt></indexterm>
+        </indexterm>
+        <indexterm><xmlelement>fig</xmlelement></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <body outputclass="language-markup">
+    <section>
+      <title>Example</title>
+      <p>By default <xmlelement>figure</xmlelement> elements are styled as shown: </p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <fig>
+        <title>A caption for the image.</title>
+        <image scope="external" href="https://picsum.photos/1200/600?a"/>
+      </fig>
+    </bodydiv>
+    <codeblock>&lt;fig&gt;
+  &lt;title&gt;A caption for the image.&lt;/title&gt;
+  &lt;image href="..."/&gt;
+&lt;/fig&gt;</codeblock>
+    <section>
+      <title>Aligning text</title>
+      <p>The figure’s caption can be aligned using the Bootstrap <xref href="./utilities.dita#colors" format="dita">text utilities</xref>.</p>
+    </section>
+     <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <fig>
+        <title outputclass="text-end">A caption for the image.</title>
+        <image scope="external" href="https://picsum.photos/1200/600?b"/>
+      </fig>
+    </bodydiv>
+    <codeblock>&lt;fig&gt;
+  &lt;title outputclass="text-end"&gt;A caption for the image.&lt;/title&gt;
+  &lt;image href="..."/&gt;
+&lt;/fig&gt;</codeblock>
+
+  <section>
+      <title>Adding borders</title>
+      <p>Use the DITA <xmlatt>frame</xmlatt> attribute to add <xref href="./utilities.dita#borders" format="dita">borders</xref> to a <xmlelement>fig</xmlelement>.</p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <fig frame="all">
+        <title>All Borders</title>
+        <codeblock>frame="all"</codeblock>
+      </fig>
+      <p/>
+      <fig frame="topbot">
+        <title>Top and Bottom Borders</title>
+        <codeblock>frame="topbot"</codeblock>
+      </fig>
+      <p/>
+      <fig frame="sides">
+        <title>Side Borders</title>
+        <codeblock>frame="sides"</codeblock>
+      </fig>
+      <p/>
+      <fig frame="top">
+        <title>Top Border only</title>
+        <codeblock>frame="top"</codeblock>
+      </fig>
+      <p/>
+      <fig frame="bottom">
+        <title>Bottom Border Only</title>
+        <codeblock>frame="bottom"</codeblock>
+      </fig>
+    </bodydiv>
+    <codeblock>&lt;fig frame="all"&gt;
+  ...
+&lt;/fig&gt;
+&lt;fig frame="topbot"&gt;
+  ...
+&lt;/fig&gt;
+&lt;fig frame="sides"&gt;
+  ...
+&lt;/fig&gt;
+&lt;fig frame="top"&gt;
+  ...
+&lt;/fig&gt;
+&lt;fig frame="bottom"&gt;
+  ...
+&lt;/fig&gt;
+    </codeblock>
+
+  </body>
+</topic>

--- a/sample/figures.dita
+++ b/sample/figures.dita
@@ -4,7 +4,11 @@
    usage of each component have been copied directly from the official Bootstrap
    5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="figures">
   <title>Figures</title>
   <abstract>

--- a/sample/figures.dita
+++ b/sample/figures.dita
@@ -14,8 +14,8 @@
   <abstract>
     <shortdesc>Documentation and examples for displaying related images and text with the figure component in Bootstrap.</shortdesc>
     <p>Anytime you need to display a piece of content—like an image with an optional caption, consider
-     using a DITA <xmlelement>fig</xmlelement> element. Bootstrap CSS classes <xmlatt>class="figure"</xmlatt> ,
-     <xmlatt>class="figure-img"</xmlatt> and <xmlatt>class="figure-caption"</xmlatt> are
+     using a DITA <xmlelement>fig</xmlelement> element. Bootstrap CSS classes <xmlatt>class="figure"</xmlatt>,
+     <xmlatt>class="figure-img"</xmlatt>, and <xmlatt>class="figure-caption"</xmlatt> are
      automatically included to the output to provide some baseline styles for the HTML5 <xmlelement>figure</xmlelement> and <xmlelement>figcaption</xmlelement> elements.
     </p>
   </abstract>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -208,6 +208,9 @@
       <indexterm><parmname>--bootstrap.css.tabs</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.tabs.vertical</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.accordion</parmname></indexterm>
+      <indexterm><parmname>--bootstrap.css.figure</parmname></indexterm>
+      <indexterm><parmname>--bootstrap.css.figure.caption</parmname></indexterm>
+      <indexterm><parmname>--bootstrap.css.figure.image</parmname></indexterm>
       <p>The HTML output for the following DITA elements can be annotated with common Bootstrap utility classes for
         <xref href="https://getbootstrap.com/docs/5.0/utilities/borders" format="html" scope="external">borders</xref>,
         <xref
@@ -231,6 +234,18 @@
         <li>
           <parmname>--bootstrap.css.header</parmname> – common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements</li>
+        <li>
+          <parmname>--bootstrap.css.figure</parmname> – common Bootstrap utility classes for DITA
+            <xmlelement>fig</xmlelement> elements
+        </li>
+        <li>
+          <parmname>--bootstrap.css.figure.caption</parmname> – common Bootstrap utility classes for DITA
+          <xmlelement>title</xmlelement> elements within <xmlelement>fig</xmlelement> elements
+        </li>
+        <li>
+          <parmname>--bootstrap.css.figure.image</parmname> – common Bootstrap utility classes for DITA
+          <xmlelement>image</xmlelement> elements within <xmlelement>fig</xmlelement> elements
+        </li>
         <li>
           <parmname>--bootstrap.css.card</parmname> – common utility classes for Bootstrap
           <xref href="./card.dita" format="dita">card components</xref>

--- a/sample/utilities.dita
+++ b/sample/utilities.dita
@@ -18,6 +18,7 @@
         <indexterm>CSS
           <indexterm><xmlatt>outputclass</xmlatt></indexterm>
         </indexterm>
+        <xmlatt>frame</xmlatt>
       </keywords>
     </metadata>
   </prolog>
@@ -39,6 +40,38 @@
 &lt;ph outputclass="border-end"&gt;...&lt;/ph&gt;
 &lt;ph outputclass="border-bottom"&gt;...&lt;/ph&gt;
 &lt;ph outputclass="border-start"&gt;...&lt;/ph&gt;</codeblock>
+    <section id="frames">
+      <title><xmlatt>frame</xmlatt> Support</title>
+      <p>For DITA elements which support the <xmlatt>frame</xmlatt> attribute, such as <xmlelement>lines</xmlelement> and
+      <xmlelement>codeblock</xmlelement>, additional frame borders are automatically added as shown:</p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <p/>
+      <codeblock outputclass="language-cpp" frame="sides">// Simple C++ program to display "Hello World"
+
+// Header file for input output functions
+#include&lt;iostream&gt;
+
+using namespace std;
+
+// main function -
+// where the execution of program begins
+int main()
+{
+    // prints hello world
+    cout&lt;&lt;"Hello World";
+    return 0;
+} </codeblock>
+       <p/>
+      <lines outputclass="bg-light" frame="topbot">Shall I compare thee to a summer's day?
+Thou art more lovely and more temperate:
+Rough winds do shake the darling buds of May,
+and summer's lease hath all too short a date:
+...</lines>
+    <p/>
+  </bodydiv>
+   <codeblock>&lt;codeblock frame="sides"&gt;...&lt;/codeblock&gt;
+&lt;lines frame="topbot" outputclass="bg-light"&gt;...&lt;/lines&gt;</codeblock>
     <section id="colors">
       <title>Colors</title>
       <p>Colorize text with color utilities</p>

--- a/sample/utilities.dita
+++ b/sample/utilities.dita
@@ -23,7 +23,7 @@
   </prolog>
   <body outputclass="language-markup">
 
-    <section>
+    <section id="border">
       <title>Border</title>
       <p>Use border utilities to add or remove an element’s borders. Choose from all borders or one at a time.</p>
     </section>
@@ -39,7 +39,7 @@
 &lt;ph outputclass="border-end"&gt;...&lt;/ph&gt;
 &lt;ph outputclass="border-bottom"&gt;...&lt;/ph&gt;
 &lt;ph outputclass="border-start"&gt;...&lt;/ph&gt;</codeblock>
-    <section>
+    <section id="colors">
       <title>Colors</title>
       <p>Colorize text with color utilities</p>
     </section>
@@ -71,7 +71,7 @@
 &lt;section outputclass="text-white bg-dark"&gt;.text-white&lt;/section&gt;
 &lt;section outputclass="text-black-50"&gt;.text-black-50&lt;/section&gt;
 &lt;section outputclass="text-white-50 bg-dark"&gt;.text-white-50&lt;/section&gt;</codeblock>
-    <section>
+    <section id="background-color">
       <title>Background color</title>
       <p>Similar to the contextual text color classes, set the background of an element to any contextual class.
         Background utilities do not set <codeph>color</codeph>, so in some cases you’ll want to use


### PR DESCRIPTION
Adds Bootstrap 5 [Figure](https://getbootstrap.com/docs/5.0/content/figures/) support


- Update XSL
- Update Documentation
- Add three parameter overrides -`bootstrap.css.figure` ,`bootstrap.css.figure.caption` , `bootstrap.css.figure.image`

Example of proper `<fig>` elements in use can be found [here](https://jason-fox.github.io/dita-ot-plugins/unit-test/usage.html)

![feature](https://user-images.githubusercontent.com/3439249/147850435-88928fda-af3b-45d3-99e0-1489cf6bb861.png)

Not just  `<fig>`, but all DITA elements which support the `@frame` display attribute are properly displayed using Bootstrap - this adds proper `@frame="sides"` support to `<codeblock>` and `<lines>`

![frame](https://user-images.githubusercontent.com/3439249/147850436-4c52b5d4-7036-4572-96ed-ca3339c6b04f.png)

