### PR TITLE
Bootstrap Popover and Tooltip Support

### DIFF
--- a/.github/dita-ot/footer.xml
+++ b/.github/dita-ot/footer.xml
@@ -28,7 +28,7 @@
       </p>
       <p class="p-3">
         <small>
-          © 2021
+          © 2017-2022
           <a class="text-dark" href="https://infotexture.net/">infotexture</a>
         </small>
       </p>

--- a/.github/dita-ot/html.xml
+++ b/.github/dita-ot/html.xml
@@ -22,6 +22,7 @@
       <param name="nav-toc" value="list-group-full"/>
       <param name="processing-mode" value="strict"/>
       <param name="icons.include" value="yes"/>
+      <param name="popovers.include" value="yes"/>
     </publication>
   </deliverable>
 </project>

--- a/Customization/xsl/popovers.xsl
+++ b/Customization/xsl/popovers.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Tooltips Component -->
-  <!-- https://getbootstrap.com/docs/5.0/components/tooltips/ -->
+  <!-- https://getbootstrap.com/docs/5.1/components/tooltips/ -->
 
 
    <xsl:template match="*" mode="add-bootstrap-popover">

--- a/Customization/xsl/popovers.xsl
+++ b/Customization/xsl/popovers.xsl
@@ -38,7 +38,7 @@
 
 
     <xsl:attribute name="title">
-      <xsl:value-of select="*[contains(@class, ' topic/data ')][1]/*[contains(@class, ' topic/title ')][1]" />
+      <xsl:value-of select="*[contains(@class, ' topic/data ')][1]/*[contains(@class, ' topic/title ')][1]"/>
     </xsl:attribute>
     <xsl:attribute name="data-bs-content">
       <xsl:value-of select="*[contains(@class, ' topic/desc ')][1]"/>
@@ -53,7 +53,9 @@
       <!-- ↓ Add Bootstrap class attributes template ↑ -->
       <xsl:apply-templates select="." mode="add-bootstrap-popover"/>
       <xsl:call-template name="commonattributes"/>
-      <xsl:apply-templates select="*[not(contains(@class, ' topic/desc '))] | text() | comment() | processing-instruction()"/>
+      <xsl:apply-templates
+        select="*[not(contains(@class, ' topic/desc '))] | text() | comment() | processing-instruction()"
+      />
     </a>
   </xsl:template>
 </xsl:stylesheet>

--- a/Customization/xsl/popovers.xsl
+++ b/Customization/xsl/popovers.xsl
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of the DITA Bootstrap plug-in for DITA Open Toolkit.
+  See the accompanying LICENSE file for applicable licenses.
+-->
+<xsl:stylesheet
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  version="2.0"
+  exclude-result-prefixes="xs xhtml dita-ot"
+>
+  <!-- Customization to add Bootstrap Tooltips Component -->
+  <!-- https://getbootstrap.com/docs/5.0/components/tooltips/ -->
+
+
+   <xsl:template match="*" mode="add-bootstrap-popover">
+    <xsl:attribute name="data-bs-toggle">
+      <xsl:text>popover</xsl:text>
+    </xsl:attribute>
+    <xsl:attribute name="data-bs-placement">
+      <xsl:choose>
+        <xsl:when test="contains(@outputclass, 'popover-left')">
+          <xsl:text>left</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@outputclass, 'popover-right')">
+          <xsl:text>right</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@outputclass, 'popover-bottom')">
+          <xsl:text>bottom</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>top</xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:attribute>
+
+
+    <xsl:attribute name="title">
+      <xsl:value-of select="*[contains(@class, ' topic/data ')][1]/*[contains(@class, ' topic/title ')][1]" />
+    </xsl:attribute>
+    <xsl:attribute name="data-bs-content">
+      <xsl:value-of select="*[contains(@class, ' topic/desc ')][1]"/>
+    </xsl:attribute>
+
+  </xsl:template>
+
+
+  <!--template for xref-->
+  <xsl:template match="*[contains(@class, ' topic/xref ') and contains(@outputclass, 'popover-')]">
+    <a>
+      <!-- ↓ Add Bootstrap class attributes template ↑ -->
+      <xsl:apply-templates select="." mode="add-bootstrap-popover"/>
+      <xsl:call-template name="commonattributes"/>
+      <xsl:apply-templates select="*[not(contains(@class, ' topic/desc '))] | text() | comment() | processing-instruction()"/>
+    </a>
+  </xsl:template>
+</xsl:stylesheet>

--- a/Customization/xsl/tooltips.xsl
+++ b/Customization/xsl/tooltips.xsl
@@ -64,8 +64,39 @@
      <xsl:value-of select="substring($htmlAsString, 7, string-length($htmlAsString) - 13)"/>
   </xsl:template>
 
+
+  <xsl:template match="*" mode="serialize">
+    <xsl:text>&lt;</xsl:text>
+    <xsl:value-of select="name()"/>
+    <xsl:apply-templates select="@*" mode="serialize" />
+    <xsl:choose>
+        <xsl:when test="node()">
+            <xsl:text>&gt;</xsl:text>
+            <xsl:apply-templates mode="serialize" />
+            <xsl:text>&lt;/</xsl:text>
+            <xsl:value-of select="name()"/>
+            <xsl:text>&gt;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text> /&gt;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="@*" mode="serialize">
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="name()"/>
+      <xsl:text>="</xsl:text>
+      <xsl:value-of select="."/>
+      <xsl:text>"</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="text()" mode="serialize">
+      <xsl:value-of select="."/>
+  </xsl:template>
+
   <!--template for xref-->
-  <xsl:template match="*[contains(@class, ' topic/xref ') and contains(@outputclass, 'tooltip-')]" name="topic.xref">
+  <xsl:template match="*[contains(@class, ' topic/xref ') and contains(@outputclass, 'tooltip-')]">
     <xsl:choose>
       <xsl:when test="@href and normalize-space(@href)">
         <a>

--- a/Customization/xsl/tooltips.xsl
+++ b/Customization/xsl/tooltips.xsl
@@ -59,7 +59,7 @@
            <xsl:apply-templates/>
         </xsl:copy>
        </xsl:variable>
-       <xsl:apply-templates select="$htmlContent"  mode="serialize"/>
+       <xsl:apply-templates select="$htmlContent" mode="serialize"/>
      </xsl:variable>
      <xsl:value-of select="substring($htmlAsString, 7, string-length($htmlAsString) - 13)"/>
   </xsl:template>
@@ -68,11 +68,11 @@
   <xsl:template match="*" mode="serialize">
     <xsl:text>&lt;</xsl:text>
     <xsl:value-of select="name()"/>
-    <xsl:apply-templates select="@*" mode="serialize" />
+    <xsl:apply-templates select="@*" mode="serialize"/>
     <xsl:choose>
         <xsl:when test="node()">
             <xsl:text>&gt;</xsl:text>
-            <xsl:apply-templates mode="serialize" />
+            <xsl:apply-templates mode="serialize"/>
             <xsl:text>&lt;/</xsl:text>
             <xsl:value-of select="name()"/>
             <xsl:text>&gt;</xsl:text>
@@ -142,7 +142,9 @@
           <!-- ↓ Add Bootstrap class attributes template ↑ -->
           <xsl:apply-templates select="." mode="add-bootstrap-tooltip"/>
           <!-- ↑ End customization · Continue with DITA-OT defaults ↓ -->
-          <xsl:apply-templates select="*[not(contains(@class, ' topic/desc '))] | text() | comment() | processing-instruction()"/>
+          <xsl:apply-templates
+            select="*[not(contains(@class, ' topic/desc '))] | text() | comment() | processing-instruction()"
+          />
         </span>
       </xsl:otherwise>
     </xsl:choose>

--- a/Customization/xsl/tooltips.xsl
+++ b/Customization/xsl/tooltips.xsl
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  This file is part of the DITA Bootstrap plug-in for DITA Open Toolkit.
+  See the accompanying LICENSE file for applicable licenses.
+-->
+<xsl:stylesheet
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:dita-ot="http://dita-ot.sourceforge.net/ns/201007/dita-ot"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  version="2.0"
+  exclude-result-prefixes="xs xhtml dita-ot"
+>
+  <!-- Customization to add Bootstrap Tooltips Component -->
+  <!-- https://getbootstrap.com/docs/5.0/components/offcanvas/ -->
+
+
+   <xsl:template match="*" mode="add-bootstrap-tooltip">
+    <xsl:attribute name="data-bs-toggle">
+      <xsl:text>tooltip</xsl:text>
+    </xsl:attribute>
+    <xsl:if test="desc/@props = 'html'">
+      <xsl:attribute name="data-bs-html">
+        <xsl:text>true</xsl:text>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:attribute name="data-bs-placement">
+      <xsl:choose>
+        <xsl:when test="contains(@outputclass, 'tooltip-left')">
+          <xsl:text>left</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@outputclass, 'tooltip-right')">
+          <xsl:text>right</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@outputclass, 'tooltip-bottom')">
+          <xsl:text>bottom</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:text>top</xsl:text>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:attribute>
+   </xsl:template>
+
+
+  <!--template for xref-->
+  <xsl:template match="*[contains(@class, ' topic/xref ') and contains(@outputclass, 'tooltip-')]" name="topic.xref">
+    <xsl:choose>
+      <xsl:when test="@href and normalize-space(@href)">
+        <a>
+          <!-- ↓ Add Bootstrap class attributes template ↑ -->
+          <xsl:apply-templates select="." mode="add-bootstrap-tooltip"/>
+          <!-- ↑ End customization · Continue with DITA-OT defaults ↓ -->
+          <xsl:call-template name="commonattributes"/>
+          <xsl:apply-templates select="." mode="add-linking-attributes"/>
+          <xsl:apply-templates select="." mode="add-desc-as-hoverhelp"/>
+          <!-- if there is text or sub element other than desc, apply templates to them
+          otherwise, use the href as the value of link text. -->
+          <xsl:choose>
+            <xsl:when test="@type = 'fn'">
+              <sup>
+                <xsl:choose>
+                  <xsl:when test="*[not(contains(@class, ' topic/desc '))] | text()">
+                    <xsl:apply-templates select="*[not(contains(@class, ' topic/desc '))] | text()"/>
+                    <!--use xref content-->
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:call-template name="href"/><!--use href text-->
+                  </xsl:otherwise>
+                </xsl:choose>
+              </sup>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:choose>
+                <xsl:when test="*[not(contains(@class, ' topic/desc '))] | text()">
+                  <xsl:apply-templates select="*[not(contains(@class, ' topic/desc '))] | text()"/>
+                  <!--use xref content-->
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:call-template name="href"/><!--use href text-->
+                </xsl:otherwise>
+              </xsl:choose>
+            </xsl:otherwise>
+          </xsl:choose>
+        </a>
+        <xsl:apply-templates select="." mode="add-xref-highlight-at-end"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <span>
+          <xsl:call-template name="commonattributes"/>
+          <!-- ↓ Add Bootstrap class attributes template ↑ -->
+          <xsl:apply-templates select="." mode="add-bootstrap-tooltip"/>
+          <!-- ↑ End customization · Continue with DITA-OT defaults ↓ -->
+          <xsl:apply-templates select="." mode="add-desc-as-hoverhelp"/>
+          <xsl:apply-templates select="*[not(contains(@class, ' topic/desc '))] | text() | comment() | processing-instruction()"/>
+        </span>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+</xsl:stylesheet>

--- a/Customization/xsl/tooltips.xsl
+++ b/Customization/xsl/tooltips.xsl
@@ -12,18 +12,13 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Tooltips Component -->
-  <!-- https://getbootstrap.com/docs/5.0/components/offcanvas/ -->
+  <!-- https://getbootstrap.com/docs/5.0/components/tooltips/ -->
 
 
    <xsl:template match="*" mode="add-bootstrap-tooltip">
     <xsl:attribute name="data-bs-toggle">
       <xsl:text>tooltip</xsl:text>
     </xsl:attribute>
-    <xsl:if test="desc/@props = 'html'">
-      <xsl:attribute name="data-bs-html">
-        <xsl:text>true</xsl:text>
-      </xsl:attribute>
-    </xsl:if>
     <xsl:attribute name="data-bs-placement">
       <xsl:choose>
         <xsl:when test="contains(@outputclass, 'tooltip-left')">
@@ -40,8 +35,72 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:attribute>
-   </xsl:template>
 
+    <xsl:choose>
+      <xsl:when test="*[contains(@class, ' topic/desc ')]/*">
+        <xsl:attribute name="data-bs-html">
+          <xsl:text>true</xsl:text>
+        </xsl:attribute>
+        <xsl:attribute name="title">
+          <xsl:apply-templates select="*[contains(@class, ' topic/desc ')][1]" mode="tooltipdesc"/>
+        </xsl:attribute>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="." mode="add-desc-as-hoverhelp"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+
+  <xsl:template match="*[contains(@class, ' topic/desc ')]" mode="tooltipdesc">
+    <xsl:for-each select="*|text()">
+      <xsl:choose>
+        <xsl:when test="contains(@class,' hi-d/b ')">
+          <xsl:text>&lt;strong&gt;</xsl:text>
+          <xsl:apply-templates/>
+          <xsl:text>&lt;/strong&gt;</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@class,' hi-d/i ')">
+          <xsl:text>&lt;em&gt;</xsl:text>
+          <xsl:apply-templates/>
+          <xsl:text>&lt;/em&gt;</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@class,' hi-d/u ')">
+          <xsl:text>&lt;u&gt;</xsl:text>
+          <xsl:apply-templates/>
+          <xsl:text>&lt;/u&gt;</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@class,' hi-d/tt ')">
+          <xsl:text>&lt;tt&gt;</xsl:text>
+          <xsl:apply-templates/>
+          <xsl:text>&lt;/tt&gt;</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@class,' hi-d/sup ')">
+          <xsl:text>&lt;sup&gt;</xsl:text>
+          <xsl:apply-templates/>
+          <xsl:text>&lt;/sup&gt;</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@class,' hi-d/sub ')">
+          <xsl:text>&lt;sub&gt;</xsl:text>
+          <xsl:apply-templates/>
+          <xsl:text>&lt;/sub&gt;</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@class,' hi-d/line-through ')">
+          <xsl:text>&lt;span style="text-decoration:line-through"&gt;</xsl:text>
+          <xsl:apply-templates/>
+          <xsl:text>&lt;/span&gt;</xsl:text>
+        </xsl:when>
+        <xsl:when test="contains(@class,' hi-d/overline ')">
+          <xsl:text>&lt;span style="text-decoration:overline"&gt;</xsl:text>
+          <xsl:apply-templates/>
+          <xsl:text>&lt;/span&gt;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:for-each>
+  </xsl:template>
 
   <!--template for xref-->
   <xsl:template match="*[contains(@class, ' topic/xref ') and contains(@outputclass, 'tooltip-')]" name="topic.xref">
@@ -53,7 +112,6 @@
           <!-- ↑ End customization · Continue with DITA-OT defaults ↓ -->
           <xsl:call-template name="commonattributes"/>
           <xsl:apply-templates select="." mode="add-linking-attributes"/>
-          <xsl:apply-templates select="." mode="add-desc-as-hoverhelp"/>
           <!-- if there is text or sub element other than desc, apply templates to them
           otherwise, use the href as the value of link text. -->
           <xsl:choose>
@@ -91,7 +149,6 @@
           <!-- ↓ Add Bootstrap class attributes template ↑ -->
           <xsl:apply-templates select="." mode="add-bootstrap-tooltip"/>
           <!-- ↑ End customization · Continue with DITA-OT defaults ↓ -->
-          <xsl:apply-templates select="." mode="add-desc-as-hoverhelp"/>
           <xsl:apply-templates select="*[not(contains(@class, ' topic/desc '))] | text() | comment() | processing-instruction()"/>
         </span>
       </xsl:otherwise>

--- a/Customization/xsl/tooltips.xsl
+++ b/Customization/xsl/tooltips.xsl
@@ -53,53 +53,15 @@
 
 
   <xsl:template match="*[contains(@class, ' topic/desc ')]" mode="tooltipdesc">
-    <xsl:for-each select="*|text()">
-      <xsl:choose>
-        <xsl:when test="contains(@class,' hi-d/b ')">
-          <xsl:text>&lt;strong&gt;</xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>&lt;/strong&gt;</xsl:text>
-        </xsl:when>
-        <xsl:when test="contains(@class,' hi-d/i ')">
-          <xsl:text>&lt;em&gt;</xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>&lt;/em&gt;</xsl:text>
-        </xsl:when>
-        <xsl:when test="contains(@class,' hi-d/u ')">
-          <xsl:text>&lt;u&gt;</xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>&lt;/u&gt;</xsl:text>
-        </xsl:when>
-        <xsl:when test="contains(@class,' hi-d/tt ')">
-          <xsl:text>&lt;tt&gt;</xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>&lt;/tt&gt;</xsl:text>
-        </xsl:when>
-        <xsl:when test="contains(@class,' hi-d/sup ')">
-          <xsl:text>&lt;sup&gt;</xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>&lt;/sup&gt;</xsl:text>
-        </xsl:when>
-        <xsl:when test="contains(@class,' hi-d/sub ')">
-          <xsl:text>&lt;sub&gt;</xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>&lt;/sub&gt;</xsl:text>
-        </xsl:when>
-        <xsl:when test="contains(@class,' hi-d/line-through ')">
-          <xsl:text>&lt;span style="text-decoration:line-through"&gt;</xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>&lt;/span&gt;</xsl:text>
-        </xsl:when>
-        <xsl:when test="contains(@class,' hi-d/overline ')">
-          <xsl:text>&lt;span style="text-decoration:overline"&gt;</xsl:text>
-          <xsl:apply-templates/>
-          <xsl:text>&lt;/span&gt;</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="."/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:for-each>
+     <xsl:variable name="htmlAsString">
+       <xsl:variable name="htmlContent">
+        <xsl:copy>
+           <xsl:apply-templates/>
+        </xsl:copy>
+       </xsl:variable>
+       <xsl:apply-templates select="$htmlContent"  mode="serialize"/>
+     </xsl:variable>
+     <xsl:value-of select="substring($htmlAsString, 7, string-length($htmlAsString) - 13)"/>
   </xsl:template>
 
   <!--template for xref-->

--- a/Customization/xsl/tooltips.xsl
+++ b/Customization/xsl/tooltips.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Tooltips Component -->
-  <!-- https://getbootstrap.com/docs/5.0/components/tooltips/ -->
+  <!-- https://getbootstrap.com/docs/5.1/components/tooltips/ -->
 
 
    <xsl:template match="*" mode="add-bootstrap-tooltip">

--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ The HTML output for the following DITA elements can be annotated with common Boo
 
 You can add your own XSLT customizations by creating a new plug-in that extends the DITA Bootstrap XSLT transforms. Just amend `args.xsl` to point to your own XSLT files. An [XSLT template][12] is included within this repository.
 
+
+### Opt-In elements
+
+For performance reasons, Bootstrap icons, popovers and tooltips are disabled by default, they can be enabled by using the following command line parameters:
+
+- `icons.include` – enable Bootstrap icons
+- `popovers.include` – enable Bootstrap popover components and tooltip components
+
 ## Feedback
 
 - If you find this useful and build something of your own on top of it, [let me know][13].
@@ -155,7 +163,7 @@ You can add your own XSLT customizations by creating a new plug-in that extends 
 
 ## License
 
-[Apache 2.0](LICENSE) © 2017–2021 Roger W. Fienhold Sheen
+[Apache 2.0](LICENSE) © 2017–2022 Roger W. Fienhold Sheen
 
 Within the sample documentation, where necessary, the texts describing the usage of each component have been copied directly from the official [Bootstrap 5.0 documentation][2], however DITA markup is used throughout the examples describing how to implement these components correctly using `outputclass`.
 

--- a/build_dita2html5-bootstrap.xml
+++ b/build_dita2html5-bootstrap.xml
@@ -46,5 +46,6 @@
     <property name="nav-toc" value="partial"/>
     <property name="args.copycss" value="yes"/>
     <property name="args.csspath" value="css"/>
+    <property name="popovers.include" value="no"/>
   </target>
 </project>

--- a/insertParameters.xml
+++ b/insertParameters.xml
@@ -1,5 +1,10 @@
 <dummy xmlns:if="ant:if" xmlns:unless="ant:unless">
   <param
+    name="BOOTSTRAP_POPOVERS_INCLUDE"
+    expression="${popovers.include}"
+    if:set="popovers.include"
+  />
+  <param
     name="BOOTSTRAP_ICONS_CDN"
     expression="${icons.cdn.path}"
     if:set="icons.cdn.path"

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,6 +34,14 @@
       <val>yes</val>
       <val default="true">no</val>
     </param>
+     <param
+      name="popovers.include"
+      desc="Specifies whether to enable popovers and tooltips"
+      type="enum"
+    >
+      <val>yes</val>
+      <val default="true">no</val>
+    </param>
     <param
       name="bootstrap.css.shortdesc"
       type="string"

--- a/sample/document.ditamap
+++ b/sample/document.ditamap
@@ -39,6 +39,7 @@
     <topicref navtitle="Carousel" format="dita" type="topic" href="carousel.dita"/>
     <topicref navtitle="List Group" format="dita" type="topic" href="list-group.dita"/>
     <topicref navtitle="Offcanvas" format="dita" type="topic" href="offcanvas.dita"/>
+    <topicref navtitle="Popovers" format="dita" type="topic" href="popovers.dita"/>
     <topicref navtitle="Tabs" format="dita" type="topic" href="tabs.dita"/>
     <topicref navtitle="Tooltips" format="dita" type="topic" href="tooltips.dita"/>
   </chapter>

--- a/sample/document.ditamap
+++ b/sample/document.ditamap
@@ -40,6 +40,7 @@
     <topicref navtitle="List Group" format="dita" type="topic" href="list-group.dita"/>
     <topicref navtitle="Offcanvas" format="dita" type="topic" href="offcanvas.dita"/>
     <topicref navtitle="Tabs" format="dita" type="topic" href="tabs.dita"/>
+    <topicref navtitle="Tooltips" format="dita" type="topic" href="tooltips.dita"/>
   </chapter>
   <chapter>
     <topicmeta>

--- a/sample/icons.dita
+++ b/sample/icons.dita
@@ -7,8 +7,11 @@
    components correctly using outputclass. -->
 <topic id="icons">
   <title>Icons</title>
-  <shortdesc>DITA Bootstrap includes Bootstrap Icons by default. Other icon libraries such as can be added or removed
-    using command line parameters.</shortdesc>
+  <shortdesc>When enabled, DITA Bootstrap includes Bootstrap Icons by default. Additional icon libraries such as
+    <xref href="https://fontawesome.com/" format="html" scope="external">Font Awesome</xref>
+    <xref href="https://feathericons.com/" format="html" scope="external">Feather</xref> and
+    <xref href="https://octicons.github.com/" format="html" scope="external">Octicons</xref>
+    can also be added using command line parameters.</shortdesc>
   <body outputclass="language-markup">
     <section>
       <title>Bootstrap Icons</title>
@@ -17,19 +20,17 @@
         library of SVG icons that are designed by @mdo and maintained by the Bootstrap Team. They are open source and
         licensed under MIT, just like Bootstrap so the icon set is freely available to everyone.</p>
     </section>
-
-
     <section>
       <title>Installing icons</title>
       <indexterm><parmname>--icons.cdn.path</parmname></indexterm>
       <indexterm><parmname>--icons.include</parmname></indexterm>
-      <p>A <xmlelement>Link</xmlelement> to the default Bootstrap Icons CDN set is included by default. If you do not
-        need any icons you can exclude them by setting the <parmname>--icons.include</parmname>=<option>no</option>
+      <p>A <xmlelement>Link</xmlelement> to the default Bootstrap Icons CDN set is not included by default. If you
+        need any icons you can include them by setting the <parmname>--icons.include</parmname>=<option>yes</option>
       </p>
       <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
         >path/to/your.ditamap</filepath> \
      <parmname>--format</parmname>=<option>html5-bootstrap</option> \
-     <parmname>--icons.include</parmname>=<option>no</option></codeblock>
+     <parmname>--icons.include</parmname>=<option>yes</option></codeblock>
       <p>Other icon sets such as
         <xref href="https://fontawesome.com/" format="html" scope="external">Font Awesome</xref>
         <xref href="https://feathericons.com/" format="html" scope="external">Feather</xref> and
@@ -48,6 +49,7 @@
       <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
         >path/to/your.ditamap</filepath> \
      <parmname>--format</parmname>=<option>html5-bootstrap</option> \
+     <parmname>--icons.include</parmname>=<option>yes</option> \
      <parmname>--icons.cdn.path</parmname>=<filepath>path/to/icon-cdn-header.xml</filepath></codeblock>
     </section>
     <section>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -257,5 +257,22 @@
         </li>
       </ul>
     </section>
+    <section>
+      <title>Opt-In elements</title>
+      <indexterm><parmname>--icons.include</parmname></indexterm>
+      <indexterm><parmname>--popovers.include</parmname></indexterm>
+      <p>
+        For performance reasons, Bootstrap <xref href="./icons.dita" format="dita">icons</xref>,
+        <xref href="./popovers.dita" format="dita">popovers</xref> and <xref href="./tooltips.dita" format="dita">tooltips</xref>
+        are disabled by default, they can be enabled by using the following command line parameters:
+      </p>
+      <ul>
+        <li>
+          <parmname>--icons.include</parmname> – enable Bootstrap <xref href="./icons.dita" format="dita">icons</xref></li>
+        <li>
+          <parmname>--popovers.include</parmname> – enable Bootstrap <xref href="./popovers.dita" format="dita">popover components</xref> and <xref href="./tooltips.dita" format="dita">tooltip components</xref></li>
+      </ul>
+    </section>
+
   </body>
 </topic>

--- a/sample/popovers.dita
+++ b/sample/popovers.dita
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<!-- Within the sample documentation, where necessary, the texts describing the
+   usage of each component have been copied directly from the official Bootstrap
+   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   markup is used throughout the examples describing how to implement these
+   components correctly using outputclass. -->
+<topic id="popovers">
+  <title>Popovers</title>
+  <shortdesc>Documentation and examples for adding Bootstrap popovers, like those found in iOS, to any element on your site.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm><parmname>--popovers.include</parmname></indexterm>
+        <indexterm>Popovers</indexterm>
+        <indexterm>CSS
+          <indexterm><xmlatt>outputclass</xmlatt></indexterm>
+        </indexterm>
+        <indexterm><xmlelement>desc</xmlelement></indexterm>
+        <indexterm><xmlelement>title</xmlelement></indexterm>
+        <indexterm><xmlelement>data</xmlelement></indexterm>
+        <indexterm><xmlelement>xref</xmlelement></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <body outputclass="language-markup">
+    <section>
+      <title>Overview</title>
+
+      <p>
+        Things to know when using the tooltip plugin:
+      </p>
+      <ul>
+        <li>
+          Popovers rely on the 3rd party library <xref scope="external" href="https://popper.js.org/">Popper</xref> for positioning.
+        </li>
+        <li>
+          Popovers are opt-in for performance reasons, so <b>you must initialize them yourself</b> by setting <parmname>--popovers.include</parmname>=<option>yes</option>
+        </li>
+        <li>
+          Popovers with a zero-length <xmlelement>desc</xmlelement> element are never displayed.
+        </li>
+        <li>
+          Triggering popovers on hidden elements will not work.
+        </li>
+        <li>
+          Popovers for <xmlatt>outputclass="disabled"</xmlatt> elements must be triggered on a wrapper element.
+        </li>
+        <li>
+          Popovers must be hidden before their corresponding elements have been removed from the DOM.
+        </li>
+        <li>
+          Popovers can be triggered thanks to an element inside a shadow DOM.
+        </li>
+      </ul>
+    </section>
+
+
+    <section deliveryTarget="html">
+      <title>Examples</title>
+      <p>Keep reading to see how popovers work with some examples.</p>
+    </section>
+
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <xref href="#" outputclass="btn-lg btn-danger popover-top">
+        <data>
+          <title>Popover title</title>
+        </data>
+        <desc>And here's some amazing content. It's very engaging. Right?</desc>
+        Click to toggle popover
+      </xref>
+    </bodydiv>
+    <codeblock> &lt;xref href="#" outputclass="btn-lg btn-danger popover-top"&gt;
+  &lt;data&gt;
+    &lt;title&gt;Popover title&lt;/title&gt;
+  &lt;/data&gt;
+  &lt;desc&gt;And here's some amazing content. It's very engaging. Right?&lt;/desc&gt;
+  Click to toggle popover
+&lt;/xref&gt;</codeblock>
+
+    <section>
+      <title>Four directions</title>
+    <p>
+        Four options are available: <codeph>top</codeph>, <codeph>right</codeph>, <codeph>bottom</codeph>, and
+        <codeph>left</codeph> aligned. Directions are mirrored when using Bootstrap in RTL. To enable popovers, add <xmlatt>output-class="popover-*"</xmlatt> to the enclosing <xmlelement>xref</xmlelement>.
+        The direction of the popover is appended to the <xmlatt>output-class</xmlatt>.
+    </p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <xref href="#" outputclass="btn-secondary popover-top">
+        <desc>Top popover</desc>
+        Popover on top
+      </xref>
+      <xref href="#" outputclass="btn-secondary popover-right">
+        <desc>Right Popover</desc>
+        Popover on right
+      </xref>
+      <xref href="#" outputclass="btn-secondary popover-bottom">
+        <desc>Bottom popover</desc>
+        Popover on bottom
+      </xref>
+      <xref href="#" outputclass="btn-secondary popover-left">
+        <desc>Left popover</desc>
+        Popover on left
+      </xref>
+    </bodydiv>
+    <codeblock>&lt;xref href="#" outputclass="btn-secondary popover-top"&gt;
+  &lt;desc&gt;Top popover&lt;/desc&gt;
+  Popover on top
+&lt;/xref&gt;
+&lt;xref href="#" outputclass="btn-secondary popover-right"&gt;
+  &lt;desc&gt;Right Popover&lt;/desc&gt;
+  Popover on right
+&lt;/xref&gt;
+&lt;xref href="#" outputclass="btn-secondary popover-bottom"&gt;
+  &lt;desc&gt;Bottom popover&lt;/desc&gt;
+  Popover on bottom
+&lt;/xref&gt;
+&lt;xref href="#" outputclass="btn-secondary popover-left"&gt;
+  &lt;desc&gt;Left popover&lt;/desc&gt;
+  Popover on left
+&lt;/xref&gt;</codeblock>
+  </body>
+</topic>
+

--- a/sample/popovers.dita
+++ b/sample/popovers.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="popovers">
   <title>Popovers</title>
   <shortdesc>Documentation and examples for adding Bootstrap popovers, like those found in iOS, to any element on your site.</shortdesc>

--- a/sample/tooltips.dita
+++ b/sample/tooltips.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="tooltips">
   <title>Tooltips</title>
   <shortdesc>Documentation and examples for adding custom Bootstrap tooltips

--- a/sample/tooltips.dita
+++ b/sample/tooltips.dita
@@ -103,9 +103,11 @@
         Tooltip on left
       </xref>
 
-      <p>When adding custom HTML to tooltips, add <xmlatt>props="html"</xmlatt> to the <xmlelement>desc</xmlelement> element</p>
+      <p>
+        Custom HTML can be added to tooltips using DITA elements in the <xmlelement>desc</xmlelement>
+      </p>
       <xref href="#" outputclass="btn-secondary tooltip-top">
-        <desc props="html">&lt;em&gt;Tooltip&lt;/em&gt; &lt;u&gt;with&lt;/u&gt; &lt;b&gt;HTML&lt;/b&gt;</desc>
+        <desc><b>Tooltip</b> <u>with</u> <b>DITA</b> elements</desc>
         Tooltip with HTML
       </xref>
     </bodydiv>
@@ -126,7 +128,7 @@
   Tooltip on left
 &lt;/xref&gt;
 &lt;xref href="#" outputclass="btn-secondary tooltip-top"&gt;
-  &lt;desc props="html"&gt;&amp;&#x2060;lt;em&amp;&#x2060;gt;Tooltip&amp;&#x2060;lt;/em&amp;&#x2060;gt; &amp;&#x2060;lt;u&amp;&#x2060;gt;with&amp;lt;/u&amp;&#x2060;gt; &amp;&#x2060;lt;b&amp;&#x2060;gt;HTML&amp;&#x2060;lt;/b&amp;&#x2060;gt;&lt;/desc&gt;
+  &lt;desc props="html"&gt;&lt;b&gt;Tooltip&lt;/b&gt; &lt;u&gt;with&amp;lt;/u&gt; &lt;b&gt;DITA&lt;/b&gt; elements&lt;/desc&gt;
   Tooltip with HTML
 &lt;/xref&gt;</codeblock>
   </body>

--- a/sample/tooltips.dita
+++ b/sample/tooltips.dita
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<!-- Within the sample documentation, where necessary, the texts describing the
+   usage of each component have been copied directly from the official Bootstrap
+   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   markup is used throughout the examples describing how to implement these
+   components correctly using outputclass. -->
+<topic id="tooltips">
+  <title>Tooltips</title>
+  <shortdesc>Documentation and examples for adding custom Bootstrap tooltips
+    with CSS and JavaScript using CSS3 for animations and <codeph>data-bs-attributes</codeph>
+    for local title storage.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>Tooltips</indexterm>
+        <indexterm>CSS
+          <indexterm><xmlatt>outputclass</xmlatt></indexterm>
+        </indexterm>
+        <indexterm><xmlatt>props</xmlatt></indexterm>
+        <indexterm><xmlelement>desc</xmlelement></indexterm>
+        <indexterm><xmlelement>xref</xmlelement></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <body outputclass="language-markup">
+    <section>
+      <title>Overview</title>
+
+      <p>
+        Things to know when using the tooltip plugin:
+      </p>
+      <ul>
+        <li>
+          Tooltips rely on the 3rd party library <xref scope="external" href="https://popper.js.org/">Popper</xref> for positioning.
+        </li>
+        <li>
+          Tooltips are opt-in for performance reasons, so <b>you must initialize them yourself</b>.
+        </li>
+        <li>
+          Tooltips with zero-length titles are never displayed.
+        </li>
+        <li>
+          Triggering tooltips on hidden elements will not work.
+        </li>
+        <li>
+          Tooltips for <codeph>.disabled</codeph> or <codeph>disabled</codeph> elements must be triggered on a wrapper element.
+        </li>
+        <li>
+          When triggered from hyperlinks that span multiple lines, tooltips will be centered. Use <codeph>white-space: nowrap;</codeph> on your <codeph>&lt;a&gt;</codeph>s to avoid this behavior.
+        </li>
+        <li>
+          Tooltips must be hidden before their corresponding elements have been removed from the DOM.
+        </li>
+        <li>
+          Tooltips can be triggered thanks to an element inside a shadow DOM.
+        </li>
+      </ul>
+    </section>
+
+
+    <section deliveryTarget="html">
+      <title>Examples</title>
+      <p>Hover over the links below to see tooltips:</p>
+    </section>
+
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+
+      <p>
+        Placeholder text to demonstrate some <xref href="#" outputclass="tooltip-top">inline links <desc>Default tooltip</desc></xref>
+        with tooltips. This is now just filler, no killer. Content placed here just to mimic the presence of
+        <xref href="#" outputclass="tooltip-top">real text<desc>Another tooltip</desc></xref>. And all that just to give
+        you an idea of how tooltips would look when used in real-world situations. So hopefully you've now seen how
+        <xref href="#" outputclass="tooltip-top">these tooltips on links<desc>Another one here too</desc></xref> can work
+        in practice, once you use them on <xref href="#" outputclass="tooltip-top">your own<desc>The last tip!</desc></xref>
+        site or project.
+      </p>
+    </bodydiv>
+
+    <p>
+        To enable tooltips, add <xmlatt>output-class="tooltip-*"</xmlatt> to the enclosing <xmlelement>xref</xmlelement>.
+        The direction of the tooltip is appended to the <xmlatt>output-class</xmlatt>.
+    </p>
+    <p>
+        Hover over the buttons below to see the four tooltips directions: top, right, bottom, and left. Directions are
+        mirrored when using Bootstrap in RTL.
+    </p>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <xref href="#" outputclass="btn-secondary tooltip-top">
+        <desc>Tooltip on top</desc>
+        Tooltip on top
+      </xref>
+      <xref href="#" outputclass="btn-secondary tooltip-right">
+        <desc>Tooltip on right</desc>
+        Tooltip on right
+      </xref>
+      <xref href="#" outputclass="btn-secondary tooltip-bottom">
+        <desc>Tooltip on bottom</desc>
+        Tooltip on bottom
+      </xref>
+      <xref href="#" outputclass="btn-secondary tooltip-left">
+        <desc>Tooltip on left</desc>
+        Tooltip on left
+      </xref>
+
+      <p>When adding custom HTML to tooltips, add <xmlatt>props="html"</xmlatt> to the <xmlelement>desc</xmlelement> element</p>
+      <xref href="#" outputclass="btn-secondary tooltip-top">
+        <desc props="html">&lt;em&gt;Tooltip&lt;/em&gt; &lt;u&gt;with&lt;/u&gt; &lt;b&gt;HTML&lt;/b&gt;</desc>
+        Tooltip with HTML
+      </xref>
+    </bodydiv>
+    <codeblock>&lt;xref href="#" outputclass="btn-secondary tooltip-top"&gt;
+  &lt;desc&gt;Tooltip on top&lt;/desc&gt;
+  Tooltip on top
+&lt;/xref&gt;
+&lt;xref href="#" outputclass="btn-secondary tooltip-right"&gt;
+  &lt;desc&gt;Tooltip on right&lt;/desc&gt;
+  Tooltip on right
+&lt;/xref&gt;
+&lt;xref href="#" outputclass="btn-secondary tooltip-bottom"&gt;
+  &lt;desc&gt;Tooltip on bottom&lt;/desc&gt;
+  Tooltip on bottom
+&lt;/xref&gt;
+&lt;xref href="#" outputclass="btn-secondary tooltip-left"&gt;
+  &lt;desc&gt;Tooltip on left&lt;/desc&gt;
+  Tooltip on left
+&lt;/xref&gt;
+&lt;xref href="#" outputclass="btn-secondary tooltip-top"&gt;
+  &lt;desc props="html"&gt;&amp;&#x2060;lt;em&amp;&#x2060;gt;Tooltip&amp;&#x2060;lt;/em&amp;&#x2060;gt; &amp;&#x2060;lt;u&amp;&#x2060;gt;with&amp;lt;/u&amp;&#x2060;gt; &amp;&#x2060;lt;b&amp;&#x2060;gt;HTML&amp;&#x2060;lt;/b&amp;&#x2060;gt;&lt;/desc&gt;
+  Tooltip with HTML
+&lt;/xref&gt;</codeblock>
+  </body>
+</topic>
+

--- a/sample/tooltips.dita
+++ b/sample/tooltips.dita
@@ -13,11 +13,11 @@
   <prolog>
     <metadata>
       <keywords>
+        <indexterm><parmname>--popovers.include</parmname></indexterm>
         <indexterm>Tooltips</indexterm>
         <indexterm>CSS
           <indexterm><xmlatt>outputclass</xmlatt></indexterm>
         </indexterm>
-        <indexterm><xmlatt>props</xmlatt></indexterm>
         <indexterm><xmlelement>desc</xmlelement></indexterm>
         <indexterm><xmlelement>xref</xmlelement></indexterm>
       </keywords>
@@ -35,16 +35,16 @@
           Tooltips rely on the 3rd party library <xref scope="external" href="https://popper.js.org/">Popper</xref> for positioning.
         </li>
         <li>
-          Tooltips are opt-in for performance reasons, so <b>you must initialize them yourself</b>.
+          Tooltips are opt-in for performance reasons, so <b>you must initialize them yourself</b> by setting <parmname>--popovers.include</parmname>=<option>yes</option>.
         </li>
         <li>
-          Tooltips with zero-length titles are never displayed.
+          Tooltips with a zero-length <xmlelement>desc</xmlelement> element are never displayed.
         </li>
         <li>
           Triggering tooltips on hidden elements will not work.
         </li>
         <li>
-          Tooltips for <xmlatt>outputclass="disabled"</xmlattr> elements must be triggered on a wrapper element.
+          Tooltips for <xmlatt>outputclass="disabled"</xmlatt> elements must be triggered on a wrapper element.
         </li>
         <li>
           Tooltips must be hidden before their corresponding elements have been removed from the DOM.
@@ -99,16 +99,7 @@
         <desc>Tooltip on left</desc>
         Tooltip on left
       </xref>
-
-      <p>
-        Custom HTML can be added to tooltips using DITA elements in the <xmlelement>desc</xmlelement>
-      </p>
-      <xref href="#" outputclass="btn-secondary tooltip-top">
-        <desc><b>Tooltip</b> <u>with</u> <b>DITA</b> elements</desc>
-        Tooltip with embedded DITA
-      </xref>
-    </bodydiv>
-    <codeblock>&lt;xref href="#" outputclass="btn-secondary tooltip-top"&gt;
+      <codeblock>&lt;xref href="#" outputclass="btn-secondary tooltip-top"&gt;
   &lt;desc&gt;Tooltip on top&lt;/desc&gt;
   Tooltip on top
 &lt;/xref&gt;
@@ -123,8 +114,16 @@
 &lt;xref href="#" outputclass="btn-secondary tooltip-left"&gt;
   &lt;desc&gt;Tooltip on left&lt;/desc&gt;
   Tooltip on left
-&lt;/xref&gt;
-&lt;xref href="#" outputclass="btn-secondary tooltip-top"&gt;
+&lt;/xref&gt;</codeblock>
+      <p>
+        Custom HTML can be added to tooltips using additional DITA elements within the <xmlelement>desc</xmlelement>
+      </p>
+      <xref href="#" outputclass="btn-secondary tooltip-top">
+        <desc><b>Tooltip</b> <u>with</u> <b>DITA</b> elements</desc>
+        Tooltip with embedded DITA
+      </xref>
+    </bodydiv>
+    <codeblock>&lt;xref href="#" outputclass="btn-secondary tooltip-top"&gt;
   &lt;desc&gt;&lt;b&gt;Tooltip&lt;/b&gt; &lt;u&gt;with&amp;lt;/u&gt; &lt;b&gt;DITA&lt;/b&gt; elements&lt;/desc&gt;
   Tooltip with embedded DITA
 &lt;/xref&gt;</codeblock>

--- a/sample/tooltips.dita
+++ b/sample/tooltips.dita
@@ -44,10 +44,7 @@
           Triggering tooltips on hidden elements will not work.
         </li>
         <li>
-          Tooltips for <codeph>.disabled</codeph> or <codeph>disabled</codeph> elements must be triggered on a wrapper element.
-        </li>
-        <li>
-          When triggered from hyperlinks that span multiple lines, tooltips will be centered. Use <codeph>white-space: nowrap;</codeph> on your <codeph>&lt;a&gt;</codeph>s to avoid this behavior.
+          Tooltips for <xmlatt>outputclass="disabled"</xmlattr> elements must be triggered on a wrapper element.
         </li>
         <li>
           Tooltips must be hidden before their corresponding elements have been removed from the DOM.
@@ -82,8 +79,8 @@
         The direction of the tooltip is appended to the <xmlatt>output-class</xmlatt>.
     </p>
     <p>
-        Hover over the buttons below to see the four tooltips directions: top, right, bottom, and left. Directions are
-        mirrored when using Bootstrap in RTL.
+        Hover over the buttons below to see the four tooltips directions: <codeph>top</codeph>, <codeph>right</codeph>, <codeph>bottom</codeph>, and
+        <codeph>left</codeph>. Directions are mirrored when using Bootstrap in RTL.
     </p>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
       <xref href="#" outputclass="btn-secondary tooltip-top">
@@ -108,7 +105,7 @@
       </p>
       <xref href="#" outputclass="btn-secondary tooltip-top">
         <desc><b>Tooltip</b> <u>with</u> <b>DITA</b> elements</desc>
-        Tooltip with HTML
+        Tooltip with embedded DITA
       </xref>
     </bodydiv>
     <codeblock>&lt;xref href="#" outputclass="btn-secondary tooltip-top"&gt;
@@ -128,8 +125,8 @@
   Tooltip on left
 &lt;/xref&gt;
 &lt;xref href="#" outputclass="btn-secondary tooltip-top"&gt;
-  &lt;desc props="html"&gt;&lt;b&gt;Tooltip&lt;/b&gt; &lt;u&gt;with&amp;lt;/u&gt; &lt;b&gt;DITA&lt;/b&gt; elements&lt;/desc&gt;
-  Tooltip with HTML
+  &lt;desc&gt;&lt;b&gt;Tooltip&lt;/b&gt; &lt;u&gt;with&amp;lt;/u&gt; &lt;b&gt;DITA&lt;/b&gt; elements&lt;/desc&gt;
+  Tooltip with embedded DITA
 &lt;/xref&gt;</codeblock>
   </body>
 </topic>

--- a/xsl/html5-bootstrap-template.xsl
+++ b/xsl/html5-bootstrap-template.xsl
@@ -23,5 +23,6 @@
   <!--xsl:include href="../Customization/xsl/tables.xsl" /-->
   <!--xsl:include href="../Customization/xsl/tabs.xsl" /-->
   <!--xsl:include href="../Customization/xsl/topic.xsl" /-->
+  <!--xsl:include href="../Customization/xsl/tooltips.xsl" /-->
   <!--xsl:include href="../Customization/xsl/utilty-classes.xsl" /-->
 </xsl:stylesheet>

--- a/xsl/html5-bootstrap-template.xsl
+++ b/xsl/html5-bootstrap-template.xsl
@@ -14,15 +14,16 @@
       To override a customization, uncomment one or more of the widgets defined
       below:
   -->
-  <!--xsl:include href="../Customization/xsl/accordion.xsl" /-->
-  <!--xsl:include href="../Customization/xsl/card.xsl" /-->
-  <!--xsl:include href="../Customization/xsl/carousel.xsl" /-->
-  <!--xsl:include href="../Customization/xsl/hi-d.xsl" /-->
-  <!--xsl:include href="../Customization/xsl/nav.xsl" /-->
-  <!--xsl:include href="../Customization/xsl/offcanvas.xsl" /-->
-  <!--xsl:include href="../Customization/xsl/tables.xsl" /-->
-  <!--xsl:include href="../Customization/xsl/tabs.xsl" /-->
-  <!--xsl:include href="../Customization/xsl/topic.xsl" /-->
-  <!--xsl:include href="../Customization/xsl/tooltips.xsl" /-->
-  <!--xsl:include href="../Customization/xsl/utilty-classes.xsl" /-->
+  <!--xsl:include href="../Customization/xsl/accordion.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/card.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/carousel.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/hi-d.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/nav.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/offcanvas.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/popovers.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/tables.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/tabs.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/topic.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/tooltips.xsl"/-->
+  <!--xsl:include href="../Customization/xsl/utilty-classes.xsl"/-->
 </xsl:stylesheet>

--- a/xsl/html5-bootstrap.xsl
+++ b/xsl/html5-bootstrap.xsl
@@ -11,8 +11,10 @@
   <!-- the file name containing XHTML to be placed in the HEAD area
        (file name and extension only - no path). -->
   <xsl:param name="BOOTSTRAP_ICONS_CDN"/>
-  <!-- Whether include bootstrap icons.  values are 'yes' or 'no' -->
+  <!-- Whether to include bootstrap icons.  values are 'yes' or 'no' -->
   <xsl:param name="BOOTSTRAP_ICONS_INCLUDE" select="'no'"/>
+  <!-- Whether to include bootstrap popovers.  values are 'yes' or 'no' -->
+  <xsl:param name="BOOTSTRAP_POPOVERS_INCLUDE" select="'no'"/>
 
   <xsl:import href="plugin:org.dita.html5:xsl/dita2html5.xsl"/>
 
@@ -22,10 +24,11 @@
   <xsl:include href="../Customization/xsl/offcanvas.xsl"/>
   <xsl:include href="../Customization/xsl/hi-d.xsl"/>
   <xsl:include href="../Customization/xsl/nav.xsl"/>
+  <xsl:include href="../Customization/xsl/popovers.xsl"/>
   <xsl:include href="../Customization/xsl/tabs.xsl"/>
   <xsl:include href="../Customization/xsl/tables.xsl"/>
   <xsl:include href="../Customization/xsl/topic.xsl"/>
-  <xsl:include href="../Customization/xsl/tooltips.xsl" />
+  <xsl:include href="../Customization/xsl/tooltips.xsl"/>
   <xsl:include href="../Customization/xsl/utility-classes.xsl"/>
 
   <!-- Override to add <meta> elements to page heads -->
@@ -94,14 +97,21 @@
         </div>
       </div>
 
-      <script language="javascript">//
-        <![CDATA[
-          var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
-          var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
-            return new bootstrap.Tooltip(tooltipTriggerEl)
-          })
-       // ]]>
-     </script>
+      <xsl:if test="$BOOTSTRAP_POPOVERS_INCLUDE = 'yes'">
+        <script language="javascript">//
+          <![CDATA[
+            var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+            var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+              return new bootstrap.Tooltip(tooltipTriggerEl)
+            })
+
+            var popoverTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="popover"]'))
+            var popoverList = popoverTriggerList.map(function (popoverTriggerEl) {
+              return new bootstrap.Popover(popoverTriggerEl)
+            })
+         // ]]>
+        </script>
+      </xsl:if>
       <!-- ↑ End customization -->
       <xsl:apply-templates select="." mode="addFooterToHtmlBodyElement"/>
     </body>
@@ -118,34 +128,4 @@
     <xsl:attribute name="class">col-lg-3</xsl:attribute>
     <xsl:attribute name="role">navigation</xsl:attribute>
   </xsl:attribute-set>
-
-  <xsl:template match="*" mode="serialize">
-    <xsl:text>&lt;</xsl:text>
-    <xsl:value-of select="name()"/>
-    <xsl:apply-templates select="@*" mode="serialize" />
-    <xsl:choose>
-        <xsl:when test="node()">
-            <xsl:text>&gt;</xsl:text>
-            <xsl:apply-templates mode="serialize" />
-            <xsl:text>&lt;/</xsl:text>
-            <xsl:value-of select="name()"/>
-            <xsl:text>&gt;</xsl:text>
-        </xsl:when>
-        <xsl:otherwise>
-            <xsl:text> /&gt;</xsl:text>
-        </xsl:otherwise>
-    </xsl:choose>
-  </xsl:template>
-
-  <xsl:template match="@*" mode="serialize">
-      <xsl:text> </xsl:text>
-      <xsl:value-of select="name()"/>
-      <xsl:text>="</xsl:text>
-      <xsl:value-of select="."/>
-      <xsl:text>"</xsl:text>
-  </xsl:template>
-
-  <xsl:template match="text()" mode="serialize">
-      <xsl:value-of select="."/>
-  </xsl:template>
 </xsl:stylesheet>

--- a/xsl/html5-bootstrap.xsl
+++ b/xsl/html5-bootstrap.xsl
@@ -25,6 +25,7 @@
   <xsl:include href="../Customization/xsl/tabs.xsl"/>
   <xsl:include href="../Customization/xsl/tables.xsl"/>
   <xsl:include href="../Customization/xsl/topic.xsl"/>
+  <xsl:include href="../Customization/xsl/tooltips.xsl" />
   <xsl:include href="../Customization/xsl/utility-classes.xsl"/>
 
   <!-- Override to add <meta> elements to page heads -->
@@ -92,6 +93,15 @@
       <!-- ↓ Close Bootstrap divs -->
         </div>
       </div>
+
+      <script language="javascript">//
+        <![CDATA[
+          var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'))
+          var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {
+            return new bootstrap.Tooltip(tooltipTriggerEl)
+          })
+       // ]]>
+     </script>
       <!-- ↑ End customization -->
       <xsl:apply-templates select="." mode="addFooterToHtmlBodyElement"/>
     </body>

--- a/xsl/html5-bootstrap.xsl
+++ b/xsl/html5-bootstrap.xsl
@@ -118,4 +118,34 @@
     <xsl:attribute name="class">col-lg-3</xsl:attribute>
     <xsl:attribute name="role">navigation</xsl:attribute>
   </xsl:attribute-set>
+
+  <xsl:template match="*" mode="serialize">
+    <xsl:text>&lt;</xsl:text>
+    <xsl:value-of select="name()"/>
+    <xsl:apply-templates select="@*" mode="serialize" />
+    <xsl:choose>
+        <xsl:when test="node()">
+            <xsl:text>&gt;</xsl:text>
+            <xsl:apply-templates mode="serialize" />
+            <xsl:text>&lt;/</xsl:text>
+            <xsl:value-of select="name()"/>
+            <xsl:text>&gt;</xsl:text>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:text> /&gt;</xsl:text>
+        </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="@*" mode="serialize">
+      <xsl:text> </xsl:text>
+      <xsl:value-of select="name()"/>
+      <xsl:text>="</xsl:text>
+      <xsl:value-of select="."/>
+      <xsl:text>"</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="text()" mode="serialize">
+      <xsl:value-of select="."/>
+  </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Adds support for Bootstrap [Tooltip](https://getbootstrap.com/docs/5.0/components/tooltips/) and [Popover](https://getbootstrap.com/docs/5.0/components/popovers/) components

- Update XSL
- Update Documentation
- Add parameter override - `popovers.include`

#### Tooltip

![tooltip](https://user-images.githubusercontent.com/3439249/147850585-42157dfa-cbd9-4dc9-9a24-c7a70d9a00e2.png)

#### Popover

![popover](https://user-images.githubusercontent.com/3439249/147850586-7ae12453-5436-4ea8-9681-10f2165c9de1.png)

Like Icons, Popovers are opt-in. The Documentation has been updated to clarify this.