### PR TITLE
Update dependencies: Bootstrap 5.1.3 & Bootstrap icons 1.7.2

### DIFF
--- a/.github/dita-ot/header.xml
+++ b/.github/dita-ot/header.xml
@@ -53,7 +53,7 @@
         <li class="nav-item">
           <a
             class="nav-link"
-            href="https://getbootstrap.com/docs/5.0"
+            href="https://getbootstrap.com/docs/5.1"
           >Bootstrap Docs</a>
         </li>
       </ul>

--- a/Customization/xsl/accordion.xsl
+++ b/Customization/xsl/accordion.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Accordion Component -->
-  <!-- https://getbootstrap.com/docs/5.0/components/accordion/ -->
+  <!-- https://getbootstrap.com/docs/5.1/components/accordion/ -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'accordion')]">
     <div>

--- a/Customization/xsl/card.xsl
+++ b/Customization/xsl/card.xsl
@@ -12,7 +12,7 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 >
   <!-- Customization to add Bootstrap Card Component -->
-  <!-- https://getbootstrap.com/docs/5.0/components/card/ -->
+  <!-- https://getbootstrap.com/docs/5.1/components/card/ -->
 
   <xsl:template match="*[contains(@class,' topic/section ') and contains(@outputclass, 'card')]">
     <div>

--- a/Customization/xsl/carousel.xsl
+++ b/Customization/xsl/carousel.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Carousel Component -->
-  <!-- https://getbootstrap.com/docs/5.0/components/carousel/ -->
+  <!-- https://getbootstrap.com/docs/5.1/components/carousel/ -->
 
   <xsl:template
     match="*[ (contains(@class,' topic/ul ') or contains(@class, ' topic/ol ')) and contains(@outputclass, 'carousel')]"

--- a/Customization/xsl/nav.xsl
+++ b/Customization/xsl/nav.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs dita-ot ditamsg"
 >
   <!-- Override to add Bootstrap list-group menu -->
-  <!-- https://getbootstrap.com/docs/5.0/components/list-group/ -->
+  <!-- https://getbootstrap.com/docs/5.1/components/list-group/ -->
 
   <xsl:param name="nav-toc" as="xs:string?"/>
   <xsl:param name="FILEDIR" as="xs:string?"/>

--- a/Customization/xsl/offcanvas.xsl
+++ b/Customization/xsl/offcanvas.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Offcanvas Component -->
-  <!-- https://getbootstrap.com/docs/5.0/components/offcanvas/ -->
+  <!-- https://getbootstrap.com/docs/5.1/components/offcanvas/ -->
 
   <xsl:template match="*[contains(@class,' topic/section ') and contains(@outputclass, 'offcanvas-')]">
     <xsl:param name="headLevel">

--- a/Customization/xsl/tabs.xsl
+++ b/Customization/xsl/tabs.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Tabbed Dialog Component -->
-  <!-- https://getbootstrap.com/docs/5.0/components/navs-tabs/#tabs -->
+  <!-- https://getbootstrap.com/docs/5.1/components/navs-tabs/#tabs -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'nav-tabs')]">
     <ul role="tablist">
@@ -29,12 +29,12 @@
   </xsl:template>
 
   <!-- Customization to add Bootstrap Tabbed Dialog with Pills Component -->
-  <!-- https://getbootstrap.com/docs/5.0/components/navs-tabs/#pills -->
+  <!-- https://getbootstrap.com/docs/5.1/components/navs-tabs/#pills -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'nav-pills')]">
     <xsl:choose>
       <!-- Pills with Vertical alignment -->
-      <!-- https://getbootstrap.com/docs/5.0/components/navs-tabs/#vertical -->
+      <!-- https://getbootstrap.com/docs/5.1/components/navs-tabs/#vertical -->
       <xsl:when test="contains(@outputclass, 'nav-pills-vertical')">
         <div class="d-flex align-items-start">
           <div role="tablist" aria-orientation="vertical">

--- a/README.md
+++ b/README.md
@@ -157,15 +157,17 @@ You can add your own XSLT customizations by creating a new plug-in that extends 
 
 [Apache 2.0](LICENSE) © 2017–2021 Roger W. Fienhold Sheen
 
-Within the sample documentation, where necessary, the texts describing the usage of each component have been copied directly from the official [Bootstrap 5.0 documentation][2], however DITA markup is used throughout the examples describing how to implement these components correctly using `outputclass`.
+Within the sample documentation, where necessary, the texts describing the usage of each component have been copied directly from the official [Bootstrap 5.1 documentation][2], however
+DITA markup is used throughout the examples describing how to implement these components correctly using `outputclass`. The text is therefore a derivative of "Bootstrap 5.1 docs" by
+Twitter, Inc. and the Bootstrap Authors, and used under CC BY 3.0.
 
 [1]: http://www.dita-ot.org
-[2]: https://getbootstrap.com/docs/5.0
-[3]: https://getbootstrap.com/docs/5.0/examples/navbars/
+[2]: https://getbootstrap.com/docs/5.1
+[3]: https://getbootstrap.com/docs/5.1/examples/navbars/
 [4]: ./includes/bs-navbar-light.hdr.xml
 [5]: ./includes/bs-footer-example.xml
 [6]: https://www.dita-ot.org/dev/parameters/parameters-html5.html#html5__nav-toc
-[7]: https://getbootstrap.com/docs/5.0/components/list-group/
+[7]: https://getbootstrap.com/docs/5.1/components/list-group/
 [8]: https://infotexture.github.io/dita-bootstrap
 [9]: https://themestr.app/theme
 [10]: ./css/custom.css

--- a/includes/bootstrap.hdf.xml
+++ b/includes/bootstrap.hdf.xml
@@ -1,13 +1,13 @@
 <div>
   <link
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
     rel="stylesheet"
-    integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
+    integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
     crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/bootstrap.icons.hdf.xml
+++ b/includes/bootstrap.icons.hdf.xml
@@ -1,4 +1,6 @@
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css"
+  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css"
+  integrity="sha384-EvBWSlnoFgZlXJvpzS+MAUEjvN7+gcCwH+qh7GRFOGgZO0PuwOFro7qPOJnLfe7l"
+  crossorigin="anonymous"
 />

--- a/sample/accordion.dita
+++ b/sample/accordion.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="accordion">
   <title>Accordion</title>
   <shortdesc>Build vertically collapsing accordions in combination with Bootstrap’s Collapse JavaScript
@@ -25,7 +29,7 @@
       <title>How it works</title>
       <p>The accordion uses
         <xref
-          href="https://getbootstrap.com/docs/5.0/components/collapse/"
+          href="https://getbootstrap.com/docs/5.1/components/collapse/"
           format="html"
           scope="external"
         >collapse</xref> internally to make it collapsible. To render an accordion that’s expanded, add the class

--- a/sample/alerts.dita
+++ b/sample/alerts.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="alerts">
   <title>Alerts</title>
   <shortdesc>Provide contextual feedback messages for typical user actions with the handful of available and flexible

--- a/sample/badge.dita
+++ b/sample/badge.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="badges">
   <title>Badges</title>
   <shortdesc>Documentation and examples for badges, Bootstrap’s small count and labeling component.</shortdesc>

--- a/sample/button-group.dita
+++ b/sample/button-group.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="button-group">
   <title>Button Group</title>
   <shortdesc>Group a series of buttons together on a single line or stack them in a vertical column.</shortdesc>

--- a/sample/buttons.dita
+++ b/sample/buttons.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="buttons">
   <title>Buttons</title>
   <shortdesc>Use Bootstrap’s custom button styles for actions in forms, dialogs, and more with support for multiple

--- a/sample/card.dita
+++ b/sample/card.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="cards">
   <title>Cards</title>
   <shortdesc>Bootstrap’s cards provide a flexible and extensible content container with multiple variants and
@@ -33,12 +37,12 @@
       <p>Cards are built with as little markup and styles as possible, but still manage to deliver a ton of control and
         customization. Built with flexbox, they offer easy alignment and mix well with other Bootstrap components. They
         have no <xmlatt>margin</xmlatt> by default, so use
-        <xref href="https://getbootstrap.com/docs/5.0/utilities/spacing/" format="html" scope="external">spacing
+        <xref href="https://getbootstrap.com/docs/5.1/utilities/spacing/" format="html" scope="external">spacing
           utilities</xref> as needed.</p>
       <p>Below is an example of a basic card with mixed content and a fixed width. Cards have no fixed width to start,
         so they’ll naturally fill the full width of its parent element. This is easily customized with Bootstrap’s
         various
-        <xref href="https://getbootstrap.com/docs/5.0/components/card/#sizing" format="html" scope="external">sizing
+        <xref href="https://getbootstrap.com/docs/5.1/components/card/#sizing" format="html" scope="external">sizing
           options.</xref>
       </p>
     </section>

--- a/sample/carousel.dita
+++ b/sample/carousel.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="carousel">
   <title>Carousel</title>
   <shortdesc>A slideshow component for cycling through elements—images or slides of text—like a carousel.</shortdesc>

--- a/sample/grid.dita
+++ b/sample/grid.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="grid">
   <title>Grid System</title>
   <shortdesc>Use Bootstrap’s powerful mobile-first flexbox grid to build layouts of all shapes and sizes thanks to a

--- a/sample/icons.dita
+++ b/sample/icons.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="icons">
   <title>Icons</title>
   <shortdesc>DITA Bootstrap includes Bootstrap Icons by default. Other icon libraries such as can be added or removed

--- a/sample/images.dita
+++ b/sample/images.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="images">
   <title>Images</title>
   <shortdesc>Documentation and examples for opting images into responsive behavior (so they never become larger than
@@ -35,7 +39,7 @@
     <section>
       <title>Image thumbnails</title>
       <p>In addition to Bootstrap’s
-        <xref href="https://getbootstrap.com/docs/5.0/utilities/borders/" format="html" scope="external">border-radius
+        <xref href="https://getbootstrap.com/docs/5.1/utilities/borders/" format="html" scope="external">border-radius
           utilities</xref>, you can set <xmlatt>outputclass</xmlatt> to <codeph>img-thumbnail</codeph> to give an image
         a rounded 1px border appearance.</p>
     </section>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="index">
   <title>DITA Bootstrap</title>
   <abstract>
@@ -15,17 +19,19 @@
         scope="external"
       >DITA Open Toolkit</xref> that extends the default HTML5
       output with a
-      <xref href="https://getbootstrap.com/docs/5.0" format="html" scope="external">Bootstrap 5.0</xref> template and
+      <xref href="https://getbootstrap.com/docs/5.1" format="html" scope="external">Bootstrap 5.1</xref> template and
       components.</shortdesc>
     <p>Where necessary, the texts describing the usage of each component have been copied directly from the
-      <xref href="https://getbootstrap.com/docs/5.0" format="html" scope="external">official Bootstrap 5.0
-        documentation</xref>, however DITA markup is used throughout the examples describing how to implement these
-      components correctly using the DITA <xmlatt>outputclass</xmlatt> attribute.</p>
+      <xref href="https://getbootstrap.com/docs/5.1" format="html" scope="external">official Bootstrap 5.1
+      documentation</xref>, however DITA markup is used throughout the examples describing how to implement these
+      components correctly using the DITA <xmlatt>outputclass</xmlatt> attribute. This text is
+      therefore a derivative of <cite>Bootstrap 5 docs</cite> by Twitter, Inc. and the Bootstrap Authors,
+      and used under <xref href="https://creativecommons.org/licenses/by/3.0/" scope="external">CC BY 3.0.</xref></p>
   </abstract>
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>Bootstrap 5.0</indexterm>
+        <indexterm>Bootstrap 5.1</indexterm>
         <indexterm>DITA</indexterm>
         <indexterm>installing</indexterm>
       </keywords>
@@ -63,7 +69,7 @@
       <p>The default header file <filepath>includes/bs-navbar-default.hdr.xml</filepath> uses the Bootstrap primary
         (blue) background color for the 
         <xref
-          href="https://getbootstrap.com/docs/5.0/examples/navbars/"
+          href="https://getbootstrap.com/docs/5.1/examples/navbars/"
           format="html"
           scope="external"
         >navbar component</xref>.</p>
@@ -112,7 +118,7 @@
       <p>As of version 5.3, the plug-in provides two new options to style the table of contents navigation with the 
         Bootstrap
         <xref
-          href="https://getbootstrap.com/docs/5.0/components/list-group/"
+          href="https://getbootstrap.com/docs/5.1/components/list-group/"
           format="html"
           scope="external"
         >list group</xref> component.
@@ -209,15 +215,15 @@
       <indexterm><parmname>--bootstrap.css.tabs.vertical</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.accordion</parmname></indexterm>
       <p>The HTML output for the following DITA elements can be annotated with common Bootstrap utility classes for
-        <xref href="https://getbootstrap.com/docs/5.0/utilities/borders" format="html" scope="external">borders</xref>,
+        <xref href="https://getbootstrap.com/docs/5.1/utilities/borders" format="html" scope="external">borders</xref>,
         <xref
-          href="https://getbootstrap.com/docs/5.0/utilities/background"
+          href="https://getbootstrap.com/docs/5.1/utilities/background"
           format="html"
           scope="external"
         >background</xref>,
-        <xref href="https://getbootstrap.com/docs/5.0/utilities/text" format="html" scope="external">text</xref>,
+        <xref href="https://getbootstrap.com/docs/5.1/utilities/text" format="html" scope="external">text</xref>,
         <xref
-          href="https://getbootstrap.com/docs/5.0/utilities/spacing"
+          href="https://getbootstrap.com/docs/5.1/utilities/spacing"
           format="html"
           scope="external"
         >spacing</xref>, etc. using additional command line parameters:</p>

--- a/sample/list-group.dita
+++ b/sample/list-group.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="list-group">
   <title>List Group</title>
   <shortdesc>List groups are a flexible and powerful component for displaying a series of content. Modify and extend

--- a/sample/offcanvas.dita
+++ b/sample/offcanvas.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="offcanvas">
   <title>Offcanvas</title>
   <shortdesc>Build hidden sidebars into your project for navigation, shopping carts, and more with a few classes and

--- a/sample/tables.dita
+++ b/sample/tables.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="tables">
   <title>Tables</title>
   <shortdesc>Documentation and examples for styling DITA tables with Bootstrap classes.</shortdesc>

--- a/sample/tabs.dita
+++ b/sample/tabs.dita
@@ -2,9 +2,13 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
 <topic id="tabs">
   <title>Tabbed Dialogs</title>
   <shortdesc>Use the tab JavaScript plugin to extend Bootstrap’s navigational tabs and pills to create tabbable panes of

--- a/sample/utilities.dita
+++ b/sample/utilities.dita
@@ -2,9 +2,14 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.0 documentation (found at https://getbootstrap.com/docs/5.0), however DITA
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
    markup is used throughout the examples describing how to implement these
-   components correctly using outputclass. -->
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0.
+
+    -->
 <topic id="cards">
   <title>Borders, Color and Background</title>
   <shortdesc>Use border utilities to quickly style the border and border-radius of an element and convey meaning through

--- a/xsl/html5-bootstrap.xsl
+++ b/xsl/html5-bootstrap.xsl
@@ -75,7 +75,7 @@
   </xsl:template>
 
   <!-- Override to add Bootstrap container & row to page -->
-  <!-- https://getbootstrap.com/docs/5.0/layout/grid -->
+  <!-- https://getbootstrap.com/docs/5.1/layout/grid -->
   <xsl:template match="*" mode="chapterBody">
     <body>
       <xsl:apply-templates select="." mode="addAttributesToHtmlBodyElement"/>
@@ -98,7 +98,7 @@
   </xsl:template>
 
   <!-- Override to add Bootstrap large grid classes. -->
-  <!-- https://getbootstrap.com/docs/5.0/layout/grid -->
+  <!-- https://getbootstrap.com/docs/5.1/layout/grid -->
   <xsl:attribute-set name="main">
     <xsl:attribute name="class">col-lg-9</xsl:attribute>
     <xsl:attribute name="role">main</xsl:attribute>


### PR DESCRIPTION
Amend header files to use the latest releases

- Bootstrap 5.1.3
- Bootstrap Icons 1.7.2

Update attribution texts to follow [best practice](https://wiki.creativecommons.org/wiki/Best_practices_for_attribution#This_is_a_good_attribution_for_material_from_which_you_created_a_derivative_work) for a derivative work.