### PR TITLE
Typography Support

### DIFF
--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -171,7 +171,16 @@
       <xsl:when test="*[contains(@class, ' topic/title ')]">
         <figcaption>
           <!-- ↑ Start customization · Add Bootstrap class ↓ -->
-          <xsl:variable name="fig-caption-class" select="concat('figure-caption ', $BOOTSTRAP_CSS_FIGURE_CAPTION)"/>
+          <xsl:variable name="fig-caption-class">
+            <xsl:choose>
+              <xsl:when test="*[contains(@class, ' topic/lq ')]">
+                  <xsl:value-of select="concat('blockquote-footer ', $BOOTSTRAP_CSS_FIGURE_CAPTION)"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:value-of select="concat('figure-caption ', $BOOTSTRAP_CSS_FIGURE_CAPTION)"/>
+              </xsl:otherwise>
+            </xsl:choose>
+         </xsl:variable>
           <xsl:apply-templates select="." mode="set-output-class">
             <xsl:with-param
               name="default"
@@ -180,7 +189,11 @@
           </xsl:apply-templates>
           <!-- ↑ End customization · Continue with DITA-OT defaults ↓ -->
           <span class="fig--title-label">
-            <xsl:choose>      <!-- Hungarian: "1. Figure " -->
+              <xsl:choose>
+              <!-- Blockquote - figure -->
+              <xsl:when test="*[contains(@class, ' topic/lq ')]">
+              </xsl:when>
+              <!-- Hungarian: "1. Figure " -->
               <xsl:when test="$ancestorlang = ('hu', 'hu-hu')">
                 <xsl:value-of select="$fig-count-actual"/>
                 <xsl:text>. </xsl:text>

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -300,4 +300,30 @@
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:template>
+
+
+  <!-- -->
+  <xsl:template match="*[contains(@class, ' topic/ph ') and contains(@otherprops, 'title(')  and (contains(@outputclass, 'initialism') or contains(@outputclass, 'abbreviation'))]">
+    <abbr>
+      <xsl:attribute name="title">
+        <xsl:analyze-string select="@otherprops" regex="[a-z]*\([^\)]*\)">
+          <xsl:matching-substring>
+            <xsl:variable name="var">
+              <xsl:value-of select="."/>
+            </xsl:variable>
+            <xsl:variable name="attr">
+              <xsl:value-of select="substring-before($var, '(')"/>
+            </xsl:variable>
+            <xsl:attribute name="{$attr}">
+              <xsl:value-of select="substring-before(substring-after($var, '('),')')"/>
+            </xsl:attribute>
+          </xsl:matching-substring>
+        </xsl:analyze-string>
+      </xsl:attribute>
+      <xsl:call-template name="commonattributes"/>
+      <xsl:call-template name="setidaname"/>
+      <xsl:apply-templates/>
+    </abbr>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -301,8 +301,6 @@
     </xsl:choose>
   </xsl:template>
 
-
-  <!-- -->
   <xsl:template match="*[contains(@class, ' topic/ph ') and contains(@otherprops, 'title(')  and (contains(@outputclass, 'initialism') or contains(@outputclass, 'abbreviation'))]">
     <abbr>
       <xsl:attribute name="title">

--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -22,6 +22,9 @@
   <xsl:param name="BOOTSTRAP_CSS_FIGURE" select="' w-100 mw-100 p-3 '"/>
   <xsl:param name="BOOTSTRAP_CSS_FIGURE_CAPTION" select="''"/>
   <xsl:param name="BOOTSTRAP_CSS_FIGURE_IMAGE" select="'img-fluid border rounded'"/>
+  <xsl:param name="BOOTSTRAP_CSS_DL" select="'row'"/>
+  <xsl:param name="BOOTSTRAP_CSS_DT" select="'col-sm-3 text-truncate '"/>
+  <xsl:param name="BOOTSTRAP_CSS_DD" select="'col-sm-9 '"/>
 
   <!-- Add a Bootstrap CSS border to codeblocks -->
   <xsl:template match="*[contains(@class, ' topic/pre ')]" mode="get-output-class">
@@ -130,6 +133,18 @@
       <xsl:when test="contains(@class, ' topic/fig ')">
         <xsl:text> figure </xsl:text>
         <xsl:value-of select="$BOOTSTRAP_CSS_FIGURE"/>
+      </xsl:when>
+      <xsl:when test="contains(@class, ' topic/lq ')">
+        <xsl:text> blockquote </xsl:text>
+      </xsl:when>
+      <xsl:when test="contains(@class, ' topic/dl ')">
+        <xsl:value-of select="$BOOTSTRAP_CSS_DL"/>
+      </xsl:when>
+      <xsl:when test="contains(@class, ' topic/dt ')">
+        <xsl:value-of select="$BOOTSTRAP_CSS_DT"/>
+      </xsl:when>
+      <xsl:when test="contains(@class, ' topic/dd ')">
+        <xsl:value-of select="$BOOTSTRAP_CSS_DD"/>
       </xsl:when>
       <xsl:when test="contains(@class, ' topic/image ') and ancestor::*[contains(@class, ' topic/fig ')]">
         <xsl:text> figure-img </xsl:text>

--- a/README.md
+++ b/README.md
@@ -143,7 +143,10 @@ The HTML output for the following DITA elements can be annotated with common Boo
 - `bootstrap.css.accordion` – common utility classes for Bootstrap accordion components
 - `bootstrap.css.figure` – common utility classes for DITA `<fig>` elements
 - `bootstrap.css.figure.caption` – common utility classes for DITA `<title>` elements within `<fig>` elements
-- `bootstrap.css.figure.image` – common utility classes for for DITA `<image>` elements within `<fig>` elements
+- `bootstrap.css.figure.image` – common utility classes for DITA `<image>` elements within `<fig>` elements
+- `bootstrap.css.dl`  – common utility classes for DITA `<dl>` elements
+- `bootstrap.css.dt`  – common utility classes for DITA `<dt>` elements
+- `bootstrap.css.dd`  – common utility classes for DITA `<dd>` elements
 
 
 You can add your own XSLT customizations by creating a new plug-in that extends the DITA Bootstrap XSLT transforms. Just amend `args.xsl` to point to your own XSLT files. An [XSLT template][12] is included within this repository.

--- a/insertParameters.xml
+++ b/insertParameters.xml
@@ -74,4 +74,19 @@
     expression="${bootstrap.css.figure.image}"
     if:set="bootstrap.css.figure.image"
   />
+  <param
+    name="BOOTSTRAP_CSS_DL"
+    expression="${bootstrap.css.dl}"
+    if:set="bootstrap.css.dl"
+  />
+  <param
+    name="BOOTSTRAP_CSS_DT"
+    expression="${bootstrap.css.dt}"
+    if:set="bootstrap.css.dt"
+  />
+  <param
+    name="BOOTSTRAP_CSS_DD"
+    expression="${bootstrap.css.dd}"
+    if:set="bootstrap.css.dd"
+  />
 </dummy>

--- a/plugin.xml
+++ b/plugin.xml
@@ -107,6 +107,21 @@
       type="string"
       desc="Bootstrap classes for figure images"
     />
+    <param
+      name="bootstrap.css.dl"
+      type="string"
+      desc="Bootstrap classes for definition lists"
+    />
+    <param
+      name="bootstrap.css.dt"
+      type="string"
+      desc="Bootstrap classes for definition list terms"
+    />
+    <param
+      name="bootstrap.css.dd"
+      type="string"
+      desc="Bootstrap classes for definition list descriptions"
+    />
   </transtype>
   <feature extension="ant.import" file="build_dita2html5-bootstrap.xml"/>
   <feature extension="extend.css.process" value="dita-bootstrap.css.copy"/>

--- a/sample/document.ditamap
+++ b/sample/document.ditamap
@@ -23,6 +23,7 @@
     <topicmeta>
       <navtitle>Content</navtitle>
     </topicmeta>
+    <topicref navtitle="Typography" format="dita" type="topic" href="typography.dita"/>
     <topicref navtitle="Images" format="dita" type="topic" href="images.dita"/>
     <topicref navtitle="Tables" format="dita" type="topic" href="tables.dita"/>
     <topicref navtitle="Figures" format="dita" type="topic" href="figures.dita"/>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -217,6 +217,9 @@
       <indexterm><parmname>--bootstrap.css.figure</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.figure.caption</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.figure.image</parmname></indexterm>
+      <indexterm><parmname>--bootstrap.css.dl</parmname></indexterm>
+      <indexterm><parmname>--bootstrap.css.dt</parmname></indexterm>
+      <indexterm><parmname>--bootstrap.css.dd</parmname></indexterm>
       <p>The HTML output for the following DITA elements can be annotated with common Bootstrap utility classes for
         <xref href="https://getbootstrap.com/docs/5.1/utilities/borders" format="html" scope="external">borders</xref>,
         <xref
@@ -251,6 +254,18 @@
         <li>
           <parmname>--bootstrap.css.figure.image</parmname> – common Bootstrap utility classes for DITA
           <xmlelement>image</xmlelement> elements within <xmlelement>fig</xmlelement> elements
+        </li>
+        <li>
+          <parmname>--bootstrap.css.dl</parmname> – common Bootstrap utility classes for DITA
+          <xmlelement>dl</xmlelement> definition list elements
+        </li>
+        <li>
+          <parmname>--bootstrap.css.dt</parmname> – common Bootstrap utility classes for DITA
+          <xmlelement>dt</xmlelement> definition term elements
+        </li>
+        <li>
+          <parmname>--bootstrap.css.dd</parmname> – common Bootstrap utility classes for DITA
+          <xmlelement>dd</xmlelement> definition description elements
         </li>
         <li>
           <parmname>--bootstrap.css.card</parmname> – common utility classes for Bootstrap

--- a/sample/typography.dita
+++ b/sample/typography.dita
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<!-- Within the sample documentation, where necessary, the texts describing the
+   usage of each component have been copied directly from the official Bootstrap
+   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   markup is used throughout the examples describing how to implement these
+   components correctly using outputclass. -->
+<topic id="typography">
+  <title>Typography</title>
+  <shortdesc>Documentation and examples for Bootstrap typography, including global settings, headings, body text, lists, and more.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>Typography</indexterm>
+        <indexterm>CSS
+          <indexterm><xmlatt>outputclass</xmlatt></indexterm>
+        </indexterm>
+        <indexterm><xmlelement>title</xmlelement></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <body outputclass="language-markup">
+    <section>
+      <title>Headings</title>
+      <p>All HTML headings, <xmlelement>h1</xmlelement> through <xmlelement>h6</xmlelement>, are available. <xmlatt>outputclass="h1"</xmlatt> through <xmlatt>outputclass="h6"</xmlatt> are also available, for when you want to match the font styling of a heading but cannot use the associated HTML element.</p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <p outputclass="h1">h1. Bootstrap heading</p>
+      <p outputclass="h2">h2. Bootstrap heading</p>
+      <p outputclass="h3">h3. Bootstrap heading</p>
+      <p outputclass="h4">h4. Bootstrap heading</p>
+      <p outputclass="h5">h5. Bootstrap heading</p>
+      <p outputclass="h6">h6. Bootstrap heading</p>
+    </bodydiv>
+    <codeblock>&lt;title outputclass="h1"&gt;h1. Bootstrap heading&lt;/title&gt;
+&lt;title outputclass="h2"&gt;h2. Bootstrap heading&lt;/title&gt;
+&lt;title outputclass="h3"&gt;h3. Bootstrap heading&lt;/title&gt;
+&lt;title outputclass="h4"&gt;h4. Bootstrap heading&lt;/title&gt;
+&lt;title outputclass="h5"&gt;h5. Bootstrap heading&lt;/title&gt;
+&lt;title outputclass="h6"&gt;h6. Bootstrap heading&lt;/title&gt;</codeblock>
+    <section>
+      <title>Customizing headings</title>
+      <p>Annotate a <xmlelement>ph</xmlelement> with an <xmlatt>outputclass</xmlatt> to recreate the small secondary heading text from Bootstrap 3.</p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <p outputclass="h3">Fancy display heading <ph outputclass="small text-muted">with faded secondary text</ph></p>
+    </bodydiv>
+    <codeblock>&lt;title&gt;Fancy display heading &lt;ph outputclass="small text-muted"&gt;with faded secondary text&lt;/ph&gt;&lt;/title&gt;</codeblock>
+    <section>
+      <title>Display headings</title>
+      <p>Traditional heading elements are designed to work best in the meat of your page content. When you need a heading to stand out, consider using a display heading — a larger, slightly more opinionated heading style.</p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <p outputclass="display-1">Display 1</p>
+      <p outputclass="display-2">Display 2</p>
+      <p outputclass="display-3">Display 3</p>
+      <p outputclass="display-4">Display 4</p>
+      <p outputclass="display-5">Display 5</p>
+      <p outputclass="display-6">Display 6</p>
+    </bodydiv>
+    <codeblock>&lt;title outputclass="display-1"&gt;Display 1&lt;/title&gt;
+&lt;title outputclass="display-2"&gt;Display 2&lt;/title&gt;
+&lt;title outputclass="display-3"&gt;Display 3&lt;/title&gt;
+&lt;title outputclass="display-4"&gt;Display 4&lt;/title&gt;
+&lt;title outputclass="display-5"&gt;Display 5&lt;/title&gt;
+&lt;title outputclass="display-6"&gt;Display 6&lt;/title&gt;</codeblock>
+    <section>
+      <title>Lead</title>
+      <p>Make a paragraph stand out by adding <xmlatt>outputclass="lead"</xmlatt> - this is automatically added to  <xmlelement>shortdesc</xmlelement> elements </p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <p outputclass="lead">
+        This is a lead paragraph. It stands out from regular paragraphs.
+      </p>
+    </bodydiv>
+    <codeblock>&lt;p outputclass="lead"&gt;
+  This is a lead paragraph. It stands out from regular paragraphs.
+&lt;/p&gt;</codeblock>
+  <section>
+    <title>Inline text elements</title>
+    <p>Styling for common inline HTML5 elements.</p>
+  </section>
+  <bodydiv outputclass="bd-example" deliveryTarget="html">
+    <p>You can use <xmlatt>outputclass="mark"</xmlatt> to <ph outputclass="mark">highlight</ph> text.</p>
+    <p><line-through>This line of text is meant to be treated as deleted text.</line-through></p>
+    <p><u>This line of text will render as underlined.</u></p>
+    <p outputclass="small">This line of text using <xmlatt>outputclass="small"</xmlatt> is meant to be treated as fine print.</p>
+    <p><b>This line rendered as bold text.</b></p>
+    <p><i>This line rendered as italicized text.</i></p>
+  </bodydiv>
+  <codeblock>&lt;p&gt;You can use &lt;xmlatt&gt;outputclass="mark"&lt;/xmlatt&gt; to &lt;ph outputclass="mark"&gt;highlight&lt;/ph&gt; text.&lt;/p&gt;
+&lt;p&gt;&lt;line-through&gt;This line of text is meant to be treated as deleted
+  text.&lt;/line-through&gt;&lt;/p&gt;
+&lt;p&gt;&lt;u&gt;This line of text will render as underlined.&lt;/u&gt;&lt;/p&gt;
+&lt;p outputclass="small"&gt;This line of text use &lt;xmlatt&gt;outputclass="small"&lt;/xmlatt&gt;
+  is meant to be treated as fine print.&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;This line rendered as bold text.&lt;/b&gt;&lt;/p&gt;
+&lt;p&gt;&lt;i&gt;This line rendered as italicized text.&lt;/i&gt;&lt;/p&gt;</codeblock>
+  <section>
+    <title>Text utilities</title>
+    <p>
+      Change text alignment, transform, style, weight, line-height, decoration and color with Bootstrap's <xref href="./utilities.dita" format="dita">text and color utilities</xref>.
+    </p>
+  </section>
+  <section>
+    <title>Blockquotes</title>
+    <p>
+      For quoting blocks of content from another source within your document use the DITA <xmlelement>lq</xmlelement>
+      element, it is styled automatically.
+    </p>
+  </section>
+  <bodydiv outputclass="bd-example" deliveryTarget="html">
+    <lq>
+      <p>A well-known quote, contained in a blockquote element.</p>
+    </lq>
+  </bodydiv>
+  <codeblock>&lt;lq&gt;
+  &lt;p&gt;A well-known quote, contained in a blockquote element.&lt;/p&gt;
+&lt;/lq&gt;</codeblock>
+  <section>
+    <title>Naming a source</title>
+    <p>
+      The HTML spec requires that blockquote attribution be placed outside the rendered HTML
+      <xmlelement>blockquote</xmlelement> element. When providing attribution, wrap your the DITA <xmlelement>lq</xmlelement>
+      in a <xmlelement>fig</xmlelement> and add a <xmlelement>title</xmlelement> to the <xmlelement>fig</xmlelement>.
+      Be sure to wrap the name of the source work in the <xmlelement>cite</xmlelement> as well.
+    </p>
+  </section>
+  <bodydiv outputclass="bd-example" deliveryTarget="html">
+    <fig>
+      <title>Someone famous in <cite>Source Title</cite></title>
+      <lq>
+        <p>A well-known quote, contained in a blockquote element.</p>
+      </lq>
+    </fig>
+  </bodydiv>
+  <codeblock>&lt;fig&gt;
+  &lt;title&gt;Someone famous in &lt;cite&gt;Source Title&lt;/cite&gt;&lt;/title&gt;
+  &lt;lq &gt;
+    &lt;p&gt;A well-known quote, contained in a blockquote element.&lt;/p&gt;
+  &lt;/lq&gt;
+&lt;/fig&gt;</codeblock>
+  <section>
+    <title>Alignment</title>
+    <p>Use text utilities such as <xmlatt>outputclass="text-center"</xmlatt> as needed to change the alignment
+    of your blockquote.</p>
+  </section>
+  <bodydiv outputclass="bd-example" deliveryTarget="html">
+    <fig outputclass="text-center">
+      <title>Someone famous in <cite>Source Title</cite></title>
+      <lq>
+        <p>A well-known quote, contained in a blockquote element.</p>
+      </lq>
+    </fig>
+  </bodydiv>
+  <codeblock>&lt;fig outputclass="text-center"&gt;
+  &lt;title&gt;Someone famous in &lt;cite&gt;Source Title&lt;/cite&gt;&lt;/title&gt;
+  &lt;lq&gt;
+    &lt;p&gt;A well-known quote, contained in a blockquote element.&lt;/p&gt;
+  &lt;/lq&gt;
+&lt;/fig&gt;</codeblock>
+  <bodydiv outputclass="bd-example" deliveryTarget="html">
+    <fig outputclass="text-end">
+      <title>Someone famous in <cite>Source Title</cite></title>
+      <lq>
+        <p>A well-known quote, contained in a blockquote element.</p>
+      </lq>
+    </fig>
+  </bodydiv>
+  <codeblock>&lt;fig outputclass="text-end"&gt;
+  &lt;title&gt;Someone famous in &lt;cite&gt;Source Title&lt;/cite&gt;&lt;/title&gt;
+  &lt;lq&gt;
+    &lt;p&gt;A well-known quote, contained in a blockquote element.&lt;/p&gt;
+  &lt;/lq&gt;
+&lt;/fig&gt;</codeblock>
+
+  <div outputclass="h2">Lists</div>
+  <section>
+    <title outputclass="h3">Unstyled</title>
+    <p>Remove the default list-style and left margin on list items (immediate children only).
+      This only applies to immediate children list items, meaning you will need to add the
+      <xmlatt>outputclass="list-unstyled"</xmlatt> for any nested lists as well.
+    </p>
+  </section>
+  <bodydiv outputclass="bd-example" deliveryTarget="html">
+    <ul outputclass="list-unstyled">
+      <li>This is a list.</li>
+      <li>It appears completely unstyled.</li>
+      <li>Structurally, it's still a list.</li>
+      <li>However, this style <b>only applies to immediate child elements</b>.</li>
+      <li>Nested lists:
+        <ul>
+          <li>are unaffected by this style</li>
+          <li>will still show a bullet</li>
+          <li>and have appropriate left margin</li>
+        </ul>
+      </li>
+      <li>This may still come in handy in some situations.</li>
+    </ul>
+  </bodydiv>
+  <codeblock>&lt;ul outputclass="list-unstyled"&gt;
+  &lt;li&gt;This is a list.&lt;/li&gt;
+  &lt;li&gt;It appears completely unstyled.&lt;/li&gt;
+  &lt;li&gt;Structurally, it's still a list.&lt;/li&gt;
+  &lt;li&gt;However, this style &lt;b&gt;only applies to immediate child elements&lt;/b&gt;.&lt;/li&gt;
+  &lt;li&gt;Nested lists:
+    &lt;ul&gt;
+      &lt;li&gt;are unaffected by this style&lt;/li&gt;
+      &lt;li&gt;will still show a bullet&lt;/li&gt;
+      &lt;li&gt;and have appropriate left margin&lt;/li&gt;
+    &lt;/ul&gt;
+  &lt;/li&gt;
+  &lt;li&gt;This may still come in handy in some situations.&lt;/li&gt;
+&lt;/ul&gt;</codeblock>
+    <section>
+      <title outputclass="h3">Inline</title>
+      <p>Remove a list’s bullets and apply some light margin with a combination of the
+        <xmlatt>outputclass="list-inline"</xmlatt> and <xmlatt>outputclass="list-inline-item"</xmlatt>
+        attributes.
+      </p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <ul outputclass="list-inline">
+        <li outputclass="list-inline-item">This is a list item.</li>
+        <li outputclass="list-inline-item">And another one.</li>
+        <li outputclass="list-inline-item">But they're displayed inline.</li>
+      </ul>
+    </bodydiv>
+    <codeblock>&lt;ul outputclass="list-inline"&gt;
+  &lt;li outputclass="list-inline-item"&gt;This is a list item.&lt;/li&gt;
+  &lt;li outputclass="list-inline-item"&gt;And another one.&lt;/li&gt;
+  &lt;li outputclass="list-inline-item"&gt;But they're displayed inline.&lt;/li&gt;
+&lt;/ul></codeblock>
+  <section>
+    <title outputclass="h3">Description list alignment</title>
+    <p>Terms and descriptions align horizontally by using Bootstrap's grid system of
+     predefined classes. For longer terms texts are to truncated with an ellipsis.</p>
+  </section>
+  <bodydiv outputclass="bd-example" deliveryTarget="html">
+    <dl>
+      <dlentry>
+        <dt>Description lists</dt>
+        <dd>A description list is perfect for defining terms.</dd>
+      </dlentry>
+      <dlentry>
+        <dt>Term</dt>
+        <dd>
+          <p>Definition for the term.</p>
+          <p>And some more placeholder definition text.</p>
+        </dd>
+      </dlentry>
+      <dlentry>
+        <dt>Another term</dt>
+        <dd>This definition is short, so no extra paragraphs or anything.</dd>
+      </dlentry>
+      <dlentry>
+        <dt>Truncated term is truncated</dt>
+        <dd>This can be useful when space is tight. Adds an ellipsis at the end.</dd>
+      </dlentry>
+      <dlentry>
+        <dt>Nesting</dt>
+        <dd>
+          <dl>
+            <dlentry>
+              <dt>Nested definition list</dt>
+              <dd>I heard you like definition lists. Let me put a definition list inside your definition list.</dd>
+            </dlentry>
+          </dl>
+        </dd>
+      </dlentry>
+    </dl>
+  </bodydiv>
+  <codeblock>&lt;dl&gt;
+  &lt;dlentry&gt;
+    &lt;dt&gt;Description lists&lt;/dt&gt;
+    &lt;dd&gt;A description list is perfect for defining terms.&lt;/dd&gt;
+  &lt;/dlentry&gt;
+  &lt;dlentry&gt;
+    &lt;dt&gt;Term&lt;/dt&gt;
+    &lt;dd&gt;
+      &lt;p&gt;Definition for the term.&lt;/p&gt;
+      &lt;p&gt;And some more placeholder definition text.&lt;/p&gt;
+    &lt;/dd&gt;
+  &lt;/dlentry&gt;
+  &lt;dlentry&gt;
+    &lt;dt&gt;Another term&lt;/dt&gt;
+    &lt;dd&gt;This definition is short, so no extra paragraphs or anything.&lt;/dd&gt;
+  &lt;/dlentry&gt;
+  &lt;dlentry&gt;
+    &lt;dt&gt;Truncated term is truncated&lt;/dt&gt;
+    &lt;dd&gt;This can be useful when space is tight. Adds an ellipsis at the end.&lt;/dd&gt;
+  &lt;/dlentry&gt;
+  &lt;dlentry&gt;
+    &lt;dt&gt;Nesting&lt;/dt&gt;
+    &lt;dd&gt;
+      &lt;dl&gt;
+        &lt;dlentry&gt;
+          &lt;dt&gt;Nested definition list&lt;/dt&gt;
+          &lt;dd&gt;I heard you like definition lists. Let me put a definition list
+            inside your definition list.&lt;/dd&gt;
+        &lt;/dlentry&gt;
+      &lt;/dl&gt;
+    &lt;/dd&gt;
+  &lt;/dlentry&gt;
+&lt;/dl&gt;</codeblock>
+  </body>
+</topic>
+
+<!--
+
+Stylized implementation of HTML’s <abbr> element for abbreviations and acronyms to show the expanded version on hover. Abbreviations have a default underline and gain a help cursor to provide additional context on hover and to users of assistive technologies.
+
+Add .initialism to an abbreviation for a slightly smaller font-size.
+
+attr
+
+HTML
+
+Copy
+<p><abbr title="attribute">attr</abbr></p>
+<p><abbr title="HyperText Markup Language" class="initialism">HTML</abbr></p>
+
+
+
+
+Description list alignment
+Align terms and descriptions horizontally by using our grid system’s predefined classes (or semantic mixins). For longer terms, you can optionally add a .text-truncate class to truncate the text with an ellipsis.
+
+Description lists
+A description list is perfect for defining terms.
+Term
+Definition for the term.
+
+And some more placeholder definition text.
+
+Another term
+This definition is short, so no extra paragraphs or anything.
+Truncated term is truncated
+This can be useful when space is tight. Adds an ellipsis at the end.
+Nesting
+Nested definition list
+I heard you like definition lists. Let me put a definition list inside your definition list.
+Copy
+<dl class="row">
+  <dt class="col-sm-3">Description lists</dt>
+  <dd class="col-sm-9">A description list is perfect for defining terms.</dd>
+
+  <dt class="col-sm-3">Term</dt>
+  <dd class="col-sm-9">
+    <p>Definition for the term.</p>
+    <p>And some more placeholder definition text.</p>
+  </dd>
+
+  <dt class="col-sm-3">Another term</dt>
+  <dd class="col-sm-9">This definition is short, so no extra paragraphs or anything.</dd>
+
+  <dt class="col-sm-3 text-truncate">Truncated term is truncated</dt>
+  <dd class="col-sm-9">This can be useful when space is tight. Adds an ellipsis at the end.</dd>
+
+  <dt class="col-sm-3">Nesting</dt>
+  <dd class="col-sm-9">
+    <dl class="row">
+      <dt class="col-sm-4">Nested definition list</dt>
+      <dd class="col-sm-8">I heard you like definition lists. Let me put a definition list inside your definition list.</dd>
+    </dl>
+  </dd>
+</dl>
+-->

--- a/sample/typography.dita
+++ b/sample/typography.dita
@@ -102,6 +102,32 @@
       Change text alignment, transform, style, weight, line-height, decoration and color with Bootstrap's <xref href="./utilities.dita" format="dita">text and color utilities</xref>.
     </p>
   </section>
+
+  <section>
+    <title>Abbreviations</title>
+    <p>Stylized implementation of HTML’s <xmlelement>abbr</xmlelement> element for abbreviations
+      and acronyms to show the expanded version on hover. Abbreviations have a default underline
+      and gain a help cursor to provide additional context on hover and to users of assistive
+      technologies.
+    </p>
+    <p>Add <xmlatt>outputclass="initialism"</xmlatt> to an abbreviation for a slightly smaller
+    font-size.</p>
+  </section>
+  <bodydiv outputclass="bd-example" deliveryTarget="html">
+    <p>
+      <ph outputclass="abbreviation" otherprops="title(attribute)">attr</ph>
+    </p>
+    <p>
+      <ph outputclass="initialism" otherprops="title(HyperText Markup Language)">HTML</ph>
+    </p>
+  </bodydiv>
+  <codeblock>&lt;p&gt;
+  &lt;ph outputclass="abbreviation" otherprops="title(attribute)"&gt;attr&lt;/ph&gt;
+&lt;/p&gt;
+&lt;p&gt;
+  &lt;ph outputclass="initialism" otherprops="title(HyperText Markup Language)"&gt;HTML&lt;/ph&gt;
+&lt;/p&gt;
+  </codeblock>
   <section>
     <title>Blockquotes</title>
     <p>
@@ -305,64 +331,3 @@
 &lt;/dl&gt;</codeblock>
   </body>
 </topic>
-
-<!--
-
-Stylized implementation of HTML’s <abbr> element for abbreviations and acronyms to show the expanded version on hover. Abbreviations have a default underline and gain a help cursor to provide additional context on hover and to users of assistive technologies.
-
-Add .initialism to an abbreviation for a slightly smaller font-size.
-
-attr
-
-HTML
-
-Copy
-<p><abbr title="attribute">attr</abbr></p>
-<p><abbr title="HyperText Markup Language" class="initialism">HTML</abbr></p>
-
-
-
-
-Description list alignment
-Align terms and descriptions horizontally by using our grid system’s predefined classes (or semantic mixins). For longer terms, you can optionally add a .text-truncate class to truncate the text with an ellipsis.
-
-Description lists
-A description list is perfect for defining terms.
-Term
-Definition for the term.
-
-And some more placeholder definition text.
-
-Another term
-This definition is short, so no extra paragraphs or anything.
-Truncated term is truncated
-This can be useful when space is tight. Adds an ellipsis at the end.
-Nesting
-Nested definition list
-I heard you like definition lists. Let me put a definition list inside your definition list.
-Copy
-<dl class="row">
-  <dt class="col-sm-3">Description lists</dt>
-  <dd class="col-sm-9">A description list is perfect for defining terms.</dd>
-
-  <dt class="col-sm-3">Term</dt>
-  <dd class="col-sm-9">
-    <p>Definition for the term.</p>
-    <p>And some more placeholder definition text.</p>
-  </dd>
-
-  <dt class="col-sm-3">Another term</dt>
-  <dd class="col-sm-9">This definition is short, so no extra paragraphs or anything.</dd>
-
-  <dt class="col-sm-3 text-truncate">Truncated term is truncated</dt>
-  <dd class="col-sm-9">This can be useful when space is tight. Adds an ellipsis at the end.</dd>
-
-  <dt class="col-sm-3">Nesting</dt>
-  <dd class="col-sm-9">
-    <dl class="row">
-      <dt class="col-sm-4">Nested definition list</dt>
-      <dd class="col-sm-8">I heard you like definition lists. Let me put a definition list inside your definition list.</dd>
-    </dl>
-  </dd>
-</dl>
--->

--- a/sample/typography.dita
+++ b/sample/typography.dita
@@ -66,7 +66,7 @@
 &lt;title outputclass="display-6"&gt;Display 6&lt;/title&gt;</codeblock>
     <section>
       <title>Lead</title>
-      <p>Make a paragraph stand out by adding <xmlatt>outputclass="lead"</xmlatt> - this is automatically added to  <xmlelement>shortdesc</xmlelement> elements </p>
+      <p>Make a paragraph stand out by adding <xmlatt>outputclass="lead"</xmlatt> — this is automatically added to <xmlelement>shortdesc</xmlelement> elements.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
       <p outputclass="lead">
@@ -92,7 +92,7 @@
 &lt;p&gt;&lt;line-through&gt;This line of text is meant to be treated as deleted
   text.&lt;/line-through&gt;&lt;/p&gt;
 &lt;p&gt;&lt;u&gt;This line of text will render as underlined.&lt;/u&gt;&lt;/p&gt;
-&lt;p outputclass="small"&gt;This line of text use &lt;xmlatt&gt;outputclass="small"&lt;/xmlatt&gt;
+&lt;p outputclass="small"&gt;This line of text using &lt;xmlatt&gt;outputclass="small"&lt;/xmlatt&gt;
   is meant to be treated as fine print.&lt;/p&gt;
 &lt;p&gt;&lt;b&gt;This line rendered as bold text.&lt;/b&gt;&lt;/p&gt;
 &lt;p&gt;&lt;i&gt;This line rendered as italicized text.&lt;/i&gt;&lt;/p&gt;</codeblock>
@@ -131,7 +131,7 @@
   <section>
     <title>Blockquotes</title>
     <p>
-      For quoting blocks of content from another source within your document use the DITA <xmlelement>lq</xmlelement>
+      For quoting blocks of content from another source within your document, use the DITA <xmlelement>lq</xmlelement>
       element, it is styled automatically.
     </p>
   </section>
@@ -259,8 +259,8 @@
 &lt;/ul></codeblock>
   <section>
     <title outputclass="h3">Description list alignment</title>
-    <p>Terms and descriptions align horizontally by using Bootstrap's grid system of
-     predefined classes. For longer terms texts are to truncated with an ellipsis.</p>
+    <p>Terms and descriptions align horizontally using Bootstrap's grid system of
+     predefined classes. For longer terms, text is truncated with an ellipsis.</p>
   </section>
   <bodydiv outputclass="bd-example" deliveryTarget="html">
     <dl>


### PR DESCRIPTION
Abbreviations, Definition List, Display Heading, Lead and Blockquote Support.

![Screenshot 2022-01-20 at 14 32 13](https://user-images.githubusercontent.com/3439249/150348511-b708f15a-900e-4bc3-acca-4442760bf45d.png)


DITA equivalents of the Bootstrap elements defined  [here](https://getbootstrap.com/docs/5.1/content/typography/) - this is mainly just documentation since the layout is triggered off `outputclass`. Blockquote support relies on Figure support as defined in PR  #20  to  some extent, so this PR extends the other one an should be reviewed after the other one has been merged and that will reduce this review down to just two commits: 017546b eb95470
