### PR TITLE
Split CSS processing for topic titles and section titles

### DIFF
--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -12,7 +12,8 @@
 >
   <xsl:param name="BOOTSTRAP_CSS_SHORTDESC" select="'text-muted lead'"/>
   <xsl:param name="BOOTSTRAP_CSS_CODEBLOCK" select="'border rounded'"/>
-  <xsl:param name="BOOTSTRAP_CSS_HEADER" select="'text-dark'"/>
+  <xsl:param name="BOOTSTRAP_CSS_TOPIC_TITLE" select="'text-dark'"/>
+  <xsl:param name="BOOTSTRAP_CSS_SECTION_TITLE" select="'h4 text-secondary'"/>
   <xsl:param name="BOOTSTRAP_CSS_CARD" select="''"/>
   <xsl:param name="BOOTSTRAP_CSS_CAROUSEL" select="''"/>
   <xsl:param name="BOOTSTRAP_CSS_CAPTION" select="'text-white bg-dark'"/>
@@ -37,8 +38,12 @@
   </xsl:template>
 
   <!-- Change the default Bootstrap CSS text color of the headers -->
-  <xsl:template match="*[contains(@class, ' topic/title ')]" mode="get-output-class">
-    <xsl:value-of select="$BOOTSTRAP_CSS_HEADER"/>
+  <xsl:template match="*[contains(@class, ' topic/topic ')]/*[contains(@class, ' topic/title ')]" mode="get-output-class">
+    <xsl:value-of select="$BOOTSTRAP_CSS_TOPIC_TITLE"/>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/section ')]/*[contains(@class, ' topic/title ')]" mode="get-output-class">
+    <xsl:value-of select="$BOOTSTRAP_CSS_SECTION_TITLE"/>
   </xsl:template>
 
   <!-- Change the default Bootstrap CSS classes of cards -->

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ The HTML output for the following DITA elements can be annotated with common Boo
 
 - `bootstrap.css.shortdesc` – common Bootstrap utility classes for DITA `<shortdesc>` elements
 - `bootstrap.css.codeblock` – common Bootstrap utility classes for DITA `<codeblock>` elements
-- `bootstrap.css.header` – common Bootstrap utility classes for DITA `<title>` elements
+- `bootstrap.css.topic.title` – common Bootstrap utility classes for DITA `<title>` elements within `<topic>` elements
+- `bootstrap.css.section.title` – common Bootstrap utility classes for DITA `<title>` elements  within `<section>` elements
 - `bootstrap.css.card` – common utility classes for Bootstrap card components
 - `bootstrap.css.carousel` – common utility classes for Bootstrap carousel components
 - `bootstrap.css.carousel.caption` – common utility classes for Bootstrap carousel captions

--- a/insertParameters.xml
+++ b/insertParameters.xml
@@ -35,9 +35,14 @@
     if:set="bootstrap.css.codeblock"
   />
   <param
-    name="BOOTSTRAP_CSS_HEADER"
-    expression="${bootstrap.css.header}"
-    if:set="bootstrap.css.header"
+    name="BOOTSTRAP_CSS_TOPIC_TITLE"
+    expression="${bootstrap.css.topic.title}"
+    if:set="bootstrap.css.topic.title"
+  />
+   <param
+    name="BOOTSTRAP_CSS_SECTION_TITLE"
+    expression="${bootstrap.css.section.title}"
+    if:set="bootstrap.css.section.title"
   />
   <param
     name="BOOTSTRAP_CSS_CARD"

--- a/plugin.xml
+++ b/plugin.xml
@@ -66,9 +66,14 @@
       desc="Common Bootstrap classes for DITA &lt;codeblock&gt; elements"
     />
     <param
-      name="bootstrap.css.header"
+      name="bootstrap.css.topic.title"
       type="string"
-      desc="Common Bootstrap classes for DITA &lt;title&gt; elements"
+      desc="Common Bootstrap classes for DITA &lt;title&gt; elements within &lt;topic&gt; elements"
+    />
+     <param
+      name="bootstrap.css.section.title"
+      type="string"
+      desc="Common Bootstrap classes for DITA &lt;title&gt; elements within &lt;section&gt; elements"
     />
     <param
       name="bootstrap.css.card"

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -211,7 +211,8 @@
       <title>Common Bootstrap utility classes</title>
       <indexterm><parmname>--bootstrap.css.shortdesc</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.codeblock</parmname></indexterm>
-      <indexterm><parmname>--bootstrap.css.header</parmname></indexterm>
+      <indexterm><parmname>--bootstrap.css.topic.title</parmname></indexterm>
+      <indexterm><parmname>--bootstrap.css.section.title</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.card</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.carousel</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.carousel.caption</parmname></indexterm>
@@ -245,8 +246,11 @@
           <parmname>--bootstrap.css.codeblock</parmname> – common Bootstrap utility classes for DITA
             <xmlelement>codeblock</xmlelement> elements</li>
         <li>
-          <parmname>--bootstrap.css.header</parmname> – common Bootstrap utility classes for DITA
-            <xmlelement>title</xmlelement> elements</li>
+          <parmname>--bootstrap.css.topic.title</parmname> – common Bootstrap utility classes for DITA
+            <xmlelement>title</xmlelement> elements within <xmlelement>topic</xmlelement> elements</li>
+        <li>
+          <parmname>--bootstrap.css.section.title</parmname> – common Bootstrap utility classes for DITA
+            <xmlelement>title</xmlelement> elements within <xmlelement>section</xmlelement> elements</li>
         <li>
           <parmname>--bootstrap.css.figure</parmname> – common Bootstrap utility classes for DITA
             <xmlelement>fig</xmlelement> elements


### PR DESCRIPTION
Given the following structure:

```xml
<topic>
  <title>Styled as Bootstrap h1</title>
  <body>
     <section>
       <title>Styled as Bootstrap h2*</title>
    </section>
  </body>
  <topic>
    <title>Styled as Bootstrap h2</title>
    <body>
     <section>
       <title>Styled as Bootstrap h3*</title>
    </section>
  </body>
 </topic>
  <topic>
    <title>Styled as Bootstrap h2</title>
    <body>
       <section>
         <title>Styled as Bootstrap h3*</title>
      </section>
    </body>
  </topic>
</topic>
```

The existing `bootstrap.css.header` param would style all the headers in the same fashion *regardless* of whether they are `<topic>` or `<section>` elements. Also the size of a `<section>` `<title>` would vary dependent upon the level of embedding. Spliting out `bootstrap.css.topic.title`  and `bootstrap.css.section.title` allows for  `<section>`  `<title>` elements to be consistently styled regardless of embedding level (in the same fashion that  the original `dita.css` without dita-bootstrap **currently** works.)

#### Example

**Installing Node.js** in the screenshot below is a sample `<section>` `<title>` styled using Bootstrap, but without this PR every `<section>` requires an `@outputclass` which is tedious and unnecessary markup.

![Screenshot 2022-02-12 at 18 32 15](https://user-images.githubusercontent.com/3439249/153722108-e81ba9d5-a94f-47ae-9141-e398075fa9bc.png)




