### PR TITLE
Fix #32 - Make `active` class for active page ancestors configurable.

### DIFF
--- a/Customization/xsl/nav.xsl
+++ b/Customization/xsl/nav.xsl
@@ -15,6 +15,7 @@
   <xsl:param name="nav-toc" as="xs:string?"/>
   <xsl:param name="FILEDIR" as="xs:string?"/>
   <xsl:param name="FILENAME" as="xs:string?"/>
+  <xsl:param name="BOOTSTRAP_CSS_ACTIVE_NAV_PARENT" select="'active'"/>
   <xsl:param name="input.map.url" as="xs:string?"/>
 
   <xsl:variable name="input.map" as="document-node()?">
@@ -30,7 +31,7 @@
       <xsl:otherwise>
         <xsl:for-each select="descendant::*">
           <xsl:if test=". is $current-topicref">
-            <xsl:value-of select="' active'"/>
+            <xsl:value-of select="concat(' ', $BOOTSTRAP_CSS_ACTIVE_NAV_PARENT)"/>
           </xsl:if>
         </xsl:for-each>
       </xsl:otherwise>

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ The HTML output for the following DITA elements can be annotated with common Boo
 - `bootstrap.css.tabs` – common utility classes for Bootstrap horizontal tab components
 - `bootstrap.css.tabs.vertical` – common utility classes for Bootstrap vertical tabs
 - `bootstrap.css.topic.title` – common Bootstrap utility classes for DITA `<topic>` titles
+- `bootstrap.css.nav.parent` - common utility classes for ancestors of active nav-pill elements
 
 You can add your own XSLT customizations by creating a new plug-in that extends the DITA Bootstrap XSLT transforms. Just amend `args.xsl` to point to your own XSLT files. An [XSLT template][12] is included within this repository.
 

--- a/insertParameters.xml
+++ b/insertParameters.xml
@@ -124,4 +124,9 @@
     expression="${bootstrap.css.pagination}"
     if:set="bootstrap.css.pagination"
   />
+   <param
+    name="BOOTSTRAP_CSS_ACTIVE_NAV_PARENT"
+    expression="${bootstrap.css.nav.parent}"
+    if:set="bootstrap.css.nav.parent"
+  />
 </dummy>

--- a/plugin.xml
+++ b/plugin.xml
@@ -177,6 +177,11 @@
       type="string"
       desc="Bootstrap classes for pagination components"
     />
+    <param
+      name="bootstrap.css.nav.parent"
+      type="string"
+      desc="Bootstrap classes for ancestors of active navbar elements"
+    />
   </transtype>
   <feature extension="ant.import" file="build_dita2html5-bootstrap.xml"/>
   <feature extension="extend.css.process" value="dita-bootstrap.css.copy"/>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -241,6 +241,7 @@
       <indexterm><parmname>--bootstrap.css.dl</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.dt</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.dd</parmname></indexterm>
+      <indexterm><parmname>--bootstrap.css.nav.parent</parmname></indexterm>
       <p>The HTML output for the following DITA elements can be annotated with common Bootstrap utility classes for
         <xref href="https://getbootstrap.com/docs/5.1/utilities/borders" format="html" scope="external">borders</xref>,
         <xref
@@ -316,6 +317,8 @@
         <li>
           <parmname>--bootstrap.css.accessibility.link</parmname> – common Bootstrap utility classes for accessibility
           links</li>
+        <li>
+          <parmname>--bootstrap.css.nav.parent</parmname> – common Bootstrap utility classes for ancestors of active nav-pill elements</li>
       </ul>
     </section>
     <section>


### PR DESCRIPTION
### Examples

#### Active ancestors (default)

```console
dita -f html5-bootstrap --nav-toc=nav-pill-full -i document.ditamap 
```

#### No active ancestors

Setting css parameter to blank removes additional bootstrap classes from ancestors

```console
 ./dita -f html5-bootstrap --nav-toc=nav-pill-full \
   --bootstrap.css.nav.parent='' -i document.ditamap
```

#### Custom active ancestors

```console
./dita -f html5-bootstrap --nav-toc=nav-pill-full \
   --bootstrap.css.nav.parent='bg-secondary text-muted' -i document.ditamap
```


