### PR TITLE
Update to Bootstrap 5.2

### DIFF
--- a/.github/dita-ot/header.xml
+++ b/.github/dita-ot/header.xml
@@ -53,7 +53,7 @@
         <li class="nav-item">
           <a
             class="nav-link"
-            href="https://getbootstrap.com/docs/5.1"
+            href="https://getbootstrap.com/docs/5.2"
           >Bootstrap Docs</a>
         </li>
       </ul>

--- a/.github/dita-ot/theme.css
+++ b/.github/dita-ot/theme.css
@@ -28,7 +28,7 @@ footer {
   --bs-popover-header-bg: var(--bs-primary);
   --bs-popover-header-color: var(--bs-white);
   --bs-popover-body-padding-x: 1rem;
-  --bs-popover-body-padding-y: .5rem;
+  --bs-popover-body-padding-y: 0.5rem;
 }
 
 .custom-tooltip {

--- a/.github/dita-ot/theme.css
+++ b/.github/dita-ot/theme.css
@@ -21,3 +21,16 @@ footer {
   margin: 1rem -0.75rem 0;
   border: solid #dee2e6 1px;
 }
+
+.custom-popover {
+  --bs-popover-max-width: 200px;
+  --bs-popover-border-color: var(--bs-primary);
+  --bs-popover-header-bg: var(--bs-primary);
+  --bs-popover-header-color: var(--bs-white);
+  --bs-popover-body-padding-x: 1rem;
+  --bs-popover-body-padding-y: .5rem;
+}
+
+.custom-tooltip {
+  --bs-tooltip-bg: var(--bs-primary);
+}

--- a/Customization/xsl/accordion.xsl
+++ b/Customization/xsl/accordion.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Accordion Component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/accordion/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/accordion/ -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'accordion')]">
     <div>

--- a/Customization/xsl/breadcrumb.xsl
+++ b/Customization/xsl/breadcrumb.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs dita-ot ditamsg"
 >
   <!-- Override to add Bootstrap breadcrumb component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/breadcrumb/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/breadcrumb/ -->
 
   <!-- Whether include a bootstrap breadcrumb component on each page.  values are 'yes' or 'no' -->
   <xsl:param name="BREADCRUMBS" select="'no'"/>

--- a/Customization/xsl/card.xsl
+++ b/Customization/xsl/card.xsl
@@ -12,7 +12,7 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 >
   <!-- Customization to add Bootstrap Card Component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/card/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/card/ -->
 
   <xsl:template match="*[contains(@class,' topic/section ') and contains(@outputclass, 'card')]">
     <div>

--- a/Customization/xsl/carousel.xsl
+++ b/Customization/xsl/carousel.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Carousel Component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/carousel/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/carousel/ -->
 
   <xsl:template
     match="*[ (contains(@class,' topic/ul ') or contains(@class, ' topic/ol ')) and contains(@outputclass, 'carousel')]"

--- a/Customization/xsl/collapse.xsl
+++ b/Customization/xsl/collapse.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Collapse Component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/collapse/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/collapse/ -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'collapse-horizontal')]">
     <xsl:variable name="id" select="dita-ot:generate-html-id(.)"/>

--- a/Customization/xsl/collapse.xsl
+++ b/Customization/xsl/collapse.xsl
@@ -15,7 +15,7 @@
   <!-- https://getbootstrap.com/docs/5.2/components/collapse/ -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'collapse-horizontal')]">
-    <xsl:variable name="id" select="dita-ot:generate-html-id(.)"/>
+    <xsl:variable name="id" select="if(@id) then dita-ot:generate-html-id(.) else generate-id(.)"/>
     <div>
       <xsl:if test="contains(@otherprops, 'style(')">
         <xsl:attribute name="style">
@@ -68,8 +68,8 @@
 
   <!-- Override to connect an collapsed element to a button -->
   <xsl:template match="*[contains(@class,' topic/xref ') and contains(@props, 'collapse-toggle')]">
-    <xsl:variable name="href" select="replace(@href, '#', '')"/>
-    <xsl:variable name="id" select="dita-ot:generate-html-id(//*[@id=$href])"/>
+    <xsl:variable name="href" select="substring-after(@href, '#')"/>
+    <xsl:variable name="id" select="if(//*[@id=$href]) then dita-ot:generate-html-id(//*[@id=$href]) else generate-id(//*[@id=$href])"/>
 
     <a data-bs-toggle="collapse">
       <xsl:call-template name="commonattributes"/>

--- a/Customization/xsl/nav.xsl
+++ b/Customization/xsl/nav.xsl
@@ -558,6 +558,8 @@
         <xsl:when test="$BOOTSTRAP_MENUBAR_TOC = 'yes' and count(ancestor::*/@href) eq 0 and not($show-menu = 'show')">
           <!-- no-op - if a menubar-toc is present, the nav-bar is reduced to current decendents only -->
         </xsl:when>
+        <xsl:when test="not(.)">
+        </xsl:when>
         <xsl:when test="normalize-space($title)">
           <xsl:variable name="id" select="dita-ot:generate-html-id(.)"/>
           <xsl:choose>

--- a/Customization/xsl/nav.xsl
+++ b/Customization/xsl/nav.xsl
@@ -202,7 +202,7 @@
   </xsl:template>
 
   <!-- list-group sidebar toc processing to add Bootstrap list-group menu -->
-  <!-- https://getbootstrap.com/docs/5.1/components/list-group/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/list-group/ -->
 
   <!-- partial list-group sidebar toc processing -->
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="list-group-toc-pull">
@@ -232,7 +232,7 @@
   </xsl:template>
 
   <!-- nav-pill sidebar toc processing to add Bootstrap nav-pills menu -->
-  <!-- https://getbootstrap.com/docs/5.1/components/navs-tabs/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/navs-tabs/ -->
 
   <!-- partial nav-pill sidebar toc processing -->
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="nav-pill-toc-pull">
@@ -262,7 +262,7 @@
   </xsl:template>
 
   <!-- collapsible sidebar toc processing to add Bootstrap collapsing menu classes -->
-  <!-- https://getbootstrap.com/docs/5.1/components/collapse/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/collapse/ -->
   <xsl:template match="*" mode="collapsible-toc" priority="-10">
     <xsl:param name="pathFromMaplist" as="xs:string"/>
     <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="collapsible-toc">
@@ -271,7 +271,7 @@
   </xsl:template>
 
   <!-- nav-pill menubar-toc submenu toc processing - a navbar with dropdowns -->
-  <!-- https://getbootstrap.com/docs/5.1/components/dropdowns/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/dropdowns/ -->
   <xsl:template match="*" mode="menubar-toc" priority="-10">
     <xsl:param name="pathFromMaplist" as="xs:string"/>
     <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="menubar-toc">

--- a/Customization/xsl/offcanvas.xsl
+++ b/Customization/xsl/offcanvas.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Offcanvas Component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/offcanvas/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/offcanvas/ -->
 
   <xsl:template match="*[contains(@class,' topic/section ') and contains(@outputclass, 'offcanvas-')]">
     <xsl:param name="headLevel">

--- a/Customization/xsl/offcanvas.xsl
+++ b/Customization/xsl/offcanvas.xsl
@@ -47,8 +47,8 @@
 
   <!-- Override to connect an offcanvas to a button -->
   <xsl:template match="*[contains(@class,' topic/xref ') and contains(@props, 'offcanvas-toggle')]">
-    <xsl:variable name="href" select="replace(@href, '#', '')"/>
-    <xsl:variable name="id" select="dita-ot:generate-html-id(../*[@id=$href])"/>
+    <xsl:variable name="href" select="substring-after(@href, '#')"/>
+    <xsl:variable name="id" select="if(//*[@id=$href]) then dita-ot:generate-html-id(//*[@id=$href]) else generate-id(//*[@id=$href])"/>
 
     <a data-bs-toggle="offcanvas">
       <xsl:call-template name="commonattributes"/>

--- a/Customization/xsl/pagination.xsl
+++ b/Customization/xsl/pagination.xsl
@@ -12,7 +12,7 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 >
   <!-- Customization to add Bootstrap Pagination Component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/pagination/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/pagination/ -->
 
   <xsl:template
     match="*[ (contains(@class, ' topic/ol ') or contains(@class, ' topic/ul ')) and contains(@outputclass, 'pagination')]"

--- a/Customization/xsl/popovers.xsl
+++ b/Customization/xsl/popovers.xsl
@@ -34,9 +34,16 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:attribute>
-    <xsl:attribute name="title">
-      <xsl:value-of select="*[contains(@class, ' topic/data ')][1]/*[contains(@class, ' topic/title ')][1]"/>
-    </xsl:attribute>
+    <xsl:if test="*[contains(@class, ' topic/data ') and contains(@name, 'title')][1]">
+      <xsl:attribute name="title">
+        <xsl:value-of select="*[contains(@class, ' topic/data ') and contains(@name, 'title')][1]"/>
+      </xsl:attribute>
+    </xsl:if>
+    <xsl:if test="*[contains(@class, ' topic/data ') and contains(@name, 'class')][1]">
+      <xsl:attribute name="data-bs-custom-class">
+        <xsl:value-of select="*[contains(@class, ' topic/data ') and contains(@name, 'class')][1]"/>
+      </xsl:attribute>
+    </xsl:if>
     <xsl:attribute name="data-bs-content">
       <xsl:value-of select="*[contains(@class, ' topic/desc ')][1]"/>
     </xsl:attribute>

--- a/Customization/xsl/popovers.xsl
+++ b/Customization/xsl/popovers.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Popover component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/popovers/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/popovers/ -->
 
   <xsl:template match="*" mode="add-bootstrap-popover">
     <xsl:attribute name="data-bs-toggle">

--- a/Customization/xsl/scrollspy.xsl
+++ b/Customization/xsl/scrollspy.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Scrollspy Component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/scrollspy/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/scrollspy/ -->
 
   <xsl:template match="*" mode="scrollspy-href">
     <xsl:call-template name="scrollspy-href"/>

--- a/Customization/xsl/tables.xsl
+++ b/Customization/xsl/tables.xsl
@@ -46,18 +46,27 @@
 
     <div>
       <!-- ↓ Add Bootstrap CSS frame processing ↑ -->
-      <xsl:if test="@frame = 'sides'">
-        <xsl:attribute name="class" select="'border-start border-end p-3'"/>
-      </xsl:if>
-      <xsl:if test="@frame = 'top'">
-        <xsl:attribute name="class" select="'border-top p-3'"/>
-      </xsl:if>
-      <xsl:if test="@frame = 'bottom'">
-        <xsl:attribute name="class" select="'border-bottom p-3'"/>
-      </xsl:if>
-      <xsl:if test="@frame = 'topbot'">
-        <xsl:attribute name="class" select="'border-top border-bottom p-3'"/>
-      </xsl:if>
+      <xsl:choose>
+        <xsl:when test="@frame = 'sides'">
+          <xsl:attribute name="class" select="'border-start border-end pt-3 ps-3 pe-3'"/>
+        </xsl:when>
+        <xsl:when test="@frame = 'top'">
+          <xsl:attribute name="class" select="'border-top pt-3'"/>
+        </xsl:when>
+        <xsl:when test="@frame = 'bottom'">
+          <xsl:attribute name="class" select="'border-bottom pt-3 ps-3 pe-3'"/>
+        </xsl:when>
+        <xsl:when test="@frame = 'topbot'">
+          <xsl:attribute name="class" select="'border-top border-bottom pt-3 ps-3 pe-3'"/>
+        </xsl:when>
+        <xsl:when test="@frame = 'all'">
+          <xsl:attribute name="class" select="'border pt-3 ps-3 pe-3'"/>
+        </xsl:when>
+        <xsl:when test="@frame = 'none'">
+          <xsl:attribute name="class" select="'border-0 pt-3 ps-3 pe-3'"/>
+        </xsl:when>
+      </xsl:choose>
+
       <!-- ↑ End customization · Continue with DITA-OT defaults ↓ -->
       <table>
         <!-- ↓ Add Bootstrap CSS class processing ↑ -->
@@ -87,6 +96,21 @@
 
   <xsl:template match="*[contains(@class, ' topic/entry ')]/@valign" mode="css-class">
     <xsl:value-of select="concat('align-', .)"/>
+  </xsl:template>
+
+  <xsl:template match="@colsep" mode="css-class">
+      <xsl:if test=".='0' and not(../@rowsep='0')">
+        <xsl:value-of select="'border-start-0 border-end-0'"/>
+      </xsl:if>
+      <xsl:if test=".='1' and not(../@rowsep='1')">
+        <xsl:value-of select="'border-start border-end'"/>
+      </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="@rowsep" mode="css-class">
+      <xsl:if test=".='0' and not(../@colsep='0')">
+        <xsl:value-of select="'border-top-0 border-bottom-0'"/>
+      </xsl:if>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/Customization/xsl/tables.xsl
+++ b/Customization/xsl/tables.xsl
@@ -14,7 +14,17 @@
   <!--override row processing - remove DITA row CSS class -->
   <xsl:template match="*[contains(@class, ' topic/row ')]" name="topic.row">
     <tr>
-      <xsl:attribute name="class" select="@outputclass"/>
+      <xsl:choose>
+        <xsl:when test="@valign">
+          <xsl:attribute name="class">
+            <xsl:value-of select="concat('align-', @valign)"/>
+            <xsl:value-of select="concat(' ', @outputclass)"/>
+          </xsl:attribute>
+        </xsl:when>
+        <xsl:when test="@outputclass">
+          <xsl:attribute name="class" select="@outputclass"/>
+        </xsl:when>
+      </xsl:choose>
       <xsl:apply-templates select="@xml:lang"/>
       <xsl:apply-templates select="@dir"/>
       <xsl:apply-templates
@@ -73,6 +83,10 @@
         "/>
       </caption>
     </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="*[contains(@class, ' topic/entry ')]/@valign" mode="css-class">
+    <xsl:value-of select="concat('align-', .)"/>
   </xsl:template>
 
 </xsl:stylesheet>

--- a/Customization/xsl/tabs.xsl
+++ b/Customization/xsl/tabs.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Tabbed Dialog Component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/navs-tabs/#tabs -->
+  <!-- https://getbootstrap.com/docs/5.2/components/navs-tabs/#tabs -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'nav-tabs')]">
     <ul role="tablist">
@@ -29,12 +29,12 @@
   </xsl:template>
 
   <!-- Customization to add Bootstrap Tabbed Dialog with Pills Component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/navs-tabs/#pills -->
+  <!-- https://getbootstrap.com/docs/5.2/components/navs-tabs/#pills -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'nav-pills')]">
     <xsl:choose>
       <!-- Pills with Vertical alignment -->
-      <!-- https://getbootstrap.com/docs/5.1/components/navs-tabs/#vertical -->
+      <!-- https://getbootstrap.com/docs/5.2/components/navs-tabs/#vertical -->
       <xsl:when test="contains(@outputclass, 'nav-pills-vertical')">
         <div class="d-flex align-items-start">
           <div role="tablist" aria-orientation="vertical">

--- a/Customization/xsl/tooltips.xsl
+++ b/Customization/xsl/tooltips.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Tooltips component -->
-  <!-- https://getbootstrap.com/docs/5.1/components/tooltips/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/tooltips/ -->
 
   <xsl:template match="*" mode="add-bootstrap-tooltip">
     <xsl:attribute name="data-bs-toggle">

--- a/Customization/xsl/tooltips.xsl
+++ b/Customization/xsl/tooltips.xsl
@@ -34,6 +34,11 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:attribute>
+    <xsl:if test="*[contains(@class, ' topic/data ') and contains(@name, 'class')][1]">
+      <xsl:attribute name="data-bs-custom-class">
+        <xsl:value-of select="*[contains(@class, ' topic/data ') and contains(@name, 'class')][1]"/>
+      </xsl:attribute>
+    </xsl:if>
     <xsl:choose>
       <xsl:when test="*[contains(@class, ' topic/desc ')]/*">
         <xsl:attribute name="data-bs-html">

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -113,7 +113,7 @@
   </xsl:template>
 
   <!-- Override to add Bootstrap Alert classes and roles to Note elements -->
-  <!-- https://getbootstrap.com/docs/5.1/components/alerts/ -->
+  <!-- https://getbootstrap.com/docs/5.2/components/alerts/ -->
   <xsl:template match="*" mode="process.note.common-processing">
     <xsl:param name="type" select="@type"/>
     <xsl:param name="title">
@@ -159,7 +159,7 @@
   </xsl:template>
 
   <!-- Customization to add Bootstrap Figure Content -->
-  <!-- https://getbootstrap.com/docs/5.1/content/figures/ -->
+  <!-- https://getbootstrap.com/docs/5.2/content/figures/ -->
   <xsl:template match="*[contains(@class, ' topic/fig ')]" name="topic.fig">
     <xsl:variable name="default-fig-class">
       <xsl:apply-templates select="." mode="dita2html:get-default-fig-class"/>
@@ -271,7 +271,7 @@
 
 
   <!-- Customization to add Bootstrap Borders to Codeblock elements-->
-  <!-- https://getbootstrap.com/docs/5.1/utilities/borders/ -->
+  <!-- https://getbootstrap.com/docs/5.2/utilities/borders/ -->
   <xsl:template match="*[contains(@class, ' topic/pre ') and @frame]">
     <xsl:variable name="default-fig-class">
       <xsl:apply-templates select="." mode="dita2html:get-default-fig-class"/>
@@ -299,7 +299,7 @@
   </xsl:template>
 
   <!-- Customization to add Bootstrap Borders to Lines elements-->
-  <!-- https://getbootstrap.com/docs/5.1/utilities/borders/ -->
+  <!-- https://getbootstrap.com/docs/5.2/utilities/borders/ -->
   <xsl:template match="*[contains(@class, ' topic/lines ') and @frame]">
     <xsl:variable name="default-fig-class">
       <xsl:apply-templates select="." mode="dita2html:get-default-fig-class"/>

--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -311,7 +311,9 @@
       <xsl:when test="@type='notice'">
         <i class="pe-2 bi bi-info-circle-fill"/>
       </xsl:when>
-      <!--xsl:when test="@type='note'"/-->
+      <xsl:when test="@type='note'">
+        <i class="pe-2 bi bi-pencil"/>
+      </xsl:when>
       <!--xsl:when test="@type='other'"/-->
     </xsl:choose>
   </xsl:template>

--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -41,8 +41,8 @@
   <xsl:template match="*[contains(@class, ' topic/table ')]" mode="get-output-class">
     <xsl:value-of select="$BOOTSTRAP_CSS_TABLE"/>
     <xsl:choose>
-      <xsl:when test="@frame = 'all'"> table-bordered</xsl:when>
-      <xsl:when test="@frame = 'none'"> table-borderless</xsl:when>
+      <xsl:when test="@colsep='1' and @rowsep='1'"> table-bordered</xsl:when>
+      <xsl:when test="@colsep='0' and @rowsep='0'"> table-borderless</xsl:when>
       <xsl:otherwise/>
     </xsl:choose>
   </xsl:template>

--- a/README.md
+++ b/README.md
@@ -196,15 +196,15 @@ Breadcrumbs and menu bars can be added using the following parameters
 
 [Apache 2.0](LICENSE) © 2017–2022 Roger W. Fienhold Sheen
 
-Within the sample documentation, where necessary, the texts describing the usage of each component have been copied directly from the official [Bootstrap 5.1 documentation][2], however DITA markup is used throughout the examples describing how to implement these components correctly using `outputclass`. The text is therefore a derivative of "Bootstrap 5.1 docs" by Twitter, Inc. and the Bootstrap Authors, and used under CC BY 3.0.
+Within the sample documentation, where necessary, the texts describing the usage of each component have been copied directly from the official [Bootstrap 5.2 documentation][2], however DITA markup is used throughout the examples describing how to implement these components correctly using `outputclass`. The text is therefore a derivative of "Bootstrap 5.2 docs" by Twitter, Inc. and the Bootstrap Authors, and used under CC BY 3.0.
 
 [1]: http://www.dita-ot.org
-[2]: https://getbootstrap.com/docs/5.1
-[3]: https://getbootstrap.com/docs/5.1/examples/navbars/
+[2]: https://getbootstrap.com/docs/5.2
+[3]: https://getbootstrap.com/docs/5.2/examples/navbars/
 [4]: ./includes/bs-navbar-light.hdr.xml
 [5]: ./includes/bs-footer-example.xml
 [6]: https://www.dita-ot.org/dev/parameters/parameters-html5.html#html5__nav-toc
-[7]: https://getbootstrap.com/docs/5.1/components/list-group/
+[7]: https://getbootstrap.com/docs/5.2/components/list-group/
 [8]: https://infotexture.github.io/dita-bootstrap
 [9]: https://themestr.app/theme
 [10]: ./css/custom.css
@@ -213,5 +213,5 @@ Within the sample documentation, where necessary, the texts describing the usage
 [13]: https://twitter.com/infotexture
 [14]: https://github.com/infotexture/dita-bootstrap/issues/new
 [15]: https://help.github.com/articles/using-pull-requests/
-[16]: https://getbootstrap.com/docs/5.1/components/navs-tabs/#pills
-[17]: https://getbootstrap.com/docs/5.1/components/collapse/
+[16]: https://getbootstrap.com/docs/5.2/components/navs-tabs/#pills
+[17]: https://getbootstrap.com/docs/5.2/components/collapse/

--- a/css/common-bootstrap.css
+++ b/css/common-bootstrap.css
@@ -8,7 +8,18 @@
 .filepath,
 .option,
 .parmname {
-  color: var(--bs-gray);
+  color: var(--bs-code-color);
+  font-family: var(--bs-font-monospace);
+}
+
+.numcharref,
+.parameterentity,
+.textentity,
+.xmlatt,
+.xmlelement,
+.xmlnsname,
+.xmlpi {
+  color: var(--bs-purple);
   font-family: var(--bs-font-monospace);
 }
 
@@ -19,11 +30,11 @@
 }
 
 .boolean {
-  color: var(--bs-success);
+  color: var(--bs-green);
 }
 
 .state {
-  color: var(--bs-danger);
+  color: var(--bs-red);
 }
 
 .navbar-brand > svg {

--- a/includes/bootstrap.hdf.xml
+++ b/includes/bootstrap.hdf.xml
@@ -1,13 +1,13 @@
 <div>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css"
-    integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css"
+    integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx"
     crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-A3rJD856KowSb7dwlZdYEkO39Gagi7vIsF0jrRAoQmDKKtQBHUuLZ9AsSv4jD4Xa"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/bootstrap.icons.hdf.xml
+++ b/includes/bootstrap.icons.hdf.xml
@@ -1,6 +1,6 @@
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.8.1/font/bootstrap-icons.css"
-  integrity="sha384-He3RckdFB2wffiHOcESa3sf4Ida+ni/fw9SSzAcfY2EPnU1zkK/sLUzw2C5Tyuhj"
+  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.9.1/font/bootstrap-icons.css"
+  integrity="sha384-xeJqLiuOvjUBq3iGOjvSQSIlwrpqjSHXpduPd6rQpuiM3f5/ijby8pCsnbu5S81n"
   crossorigin="anonymous"
 />

--- a/sample/accordion.dita
+++ b/sample/accordion.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="accordion">
@@ -29,7 +29,7 @@
       <title>How it works</title>
       <p>The accordion uses
         <xref
-          href="https://getbootstrap.com/docs/5.1/components/collapse/"
+          href="https://getbootstrap.com/docs/5.2/components/collapse/"
           format="html"
           scope="external"
         >collapse</xref> internally to make it collapsible. To render an accordion that’s expanded, add the class

--- a/sample/alerts.dita
+++ b/sample/alerts.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="alerts">

--- a/sample/badge.dita
+++ b/sample/badge.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="badges">

--- a/sample/badge.dita
+++ b/sample/badge.dita
@@ -43,7 +43,10 @@
 &lt;p&gt;Example Text &lt;ph outputclass="bg-secondary"&gt;New&lt;/ph&gt;&lt;/p&gt;</codeblock>
     <section>
       <title>Background colors</title>
-      <p>Set a background-color with contrasting foreground color with Bootstrap’s <codeph>text-bg-{color}</codeph> helpers. Previously it was required to manually pair your choice of <xmlatt>outputclass</xmlatt> <codeph>text-{color}</codeph> and <codeph>bg-{color}</codeph> utilities for styling, which you still may use if you prefer.</p>
+      <p>Set a background-color with contrasting foreground color with Bootstrap’s <codeph
+        >text-bg-{color}</codeph> helpers. Previously it was required to manually pair your choice of <xmlatt
+        >outputclass</xmlatt> <codeph>text-{color}</codeph> and <codeph
+        >bg-{color}</codeph> utilities for styling, which you still may use if you prefer.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
       <ph outputclass="text-bg-primary">Primary</ph>

--- a/sample/badge.dita
+++ b/sample/badge.dita
@@ -43,29 +43,25 @@
 &lt;p&gt;Example Text &lt;ph outputclass="bg-secondary"&gt;New&lt;/ph&gt;&lt;/p&gt;</codeblock>
     <section>
       <title>Background colors</title>
-      <p>Use Bootstrap’s background utility classes to quickly change the appearance of a badge. Please note that when
-        using Bootstrap’s default CSS classes using the DITA <xmlatt>outputclass</xmlatt> attribute with the value
-          <codeph>bg-light</codeph>, you’ll likely need a text color utility attribute on <xmlatt>outputclass</xmlatt>
-        like <codeph>text-dark</codeph> as well for proper styling. This is because background utilities do not set
-        anything but background-color.</p>
+      <p>Set a background-color with contrasting foreground color with Bootstrap’s <codeph>text-bg-{color}</codeph> helpers. Previously it was required to manually pair your choice of <xmlatt>outputclass</xmlatt> <codeph>text-{color}</codeph> and <codeph>bg-{color}</codeph> utilities for styling, which you still may use if you prefer.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
-      <ph outputclass="bg-primary">Primary</ph>
-      <ph outputclass="bg-secondary">Secondary</ph>
-      <ph outputclass="bg-success">Success</ph>
-      <ph outputclass="bg-danger">Danger</ph>
-      <ph outputclass="bg-warning text-dark">Warning</ph>
-      <ph outputclass="bg-info text-dark">Info</ph>
-      <ph outputclass="bg-light text-dark">Light</ph>
-      <ph outputclass="bg-dark">Dark</ph>
+      <ph outputclass="text-bg-primary">Primary</ph>
+      <ph outputclass="text-bg-secondary">Secondary</ph>
+      <ph outputclass="text-bg-success">Success</ph>
+      <ph outputclass="text-bg-danger">Danger</ph>
+      <ph outputclass="text-bg-warning">Warning</ph>
+      <ph outputclass="text-bg-info">Info</ph>
+      <ph outputclass="text-bg-light">Light</ph>
+      <ph outputclass="text-bg-dark">Dark</ph>
     </bodydiv>
-    <codeblock>&lt;ph outputclass="bg-primary"&gt;Primary&lt;/ph&gt;
-&lt;ph outputclass="bg-secondary"&gt;Secondary&lt;/ph&gt;
-&lt;ph outputclass="bg-success"&gt;Success&lt;/ph&gt;
-&lt;ph outputclass="bg-danger"&gt;Danger&lt;/ph&gt;
-&lt;ph outputclass="bg-warning text-dark"&gt;Warning&lt;/ph&gt;
-&lt;ph outputclass="bg-info text-dark"&gt;Info&lt;/ph&gt;
-&lt;ph outputclass="bg-light text-dark"&gt;Light&lt;/ph&gt;
-&lt;ph outputclass="bg-dark"&gt;Dark&lt;/ph&gt;</codeblock>
+    <codeblock>&lt;ph outputclass="text-bg-primary"&gt;Primary&lt;/ph&gt;
+&lt;ph outputclass="text-bg-secondary"&gt;Secondary&lt;/ph&gt;
+&lt;ph outputclass="text-bg-success"&gt;Success&lt;/ph&gt;
+&lt;ph outputclass="text-bg-danger"&gt;Danger&lt;/ph&gt;
+&lt;ph outputclass="text-bg-warning"&gt;Warning&lt;/ph&gt;
+&lt;ph outputclass="text-bg-info"&gt;Info&lt;/ph&gt;
+&lt;ph outputclass="text-bg-light"&gt;Light&lt;/ph&gt;
+&lt;ph outputclass="text-bg-dark"&gt;Dark&lt;/ph&gt;</codeblock>
   </body>
 </topic>

--- a/sample/breadcrumb.dita
+++ b/sample/breadcrumb.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="breadcrumb">

--- a/sample/button-group.dita
+++ b/sample/button-group.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="button-group">

--- a/sample/buttons.dita
+++ b/sample/buttons.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="buttons">

--- a/sample/card.dita
+++ b/sample/card.dita
@@ -51,7 +51,7 @@
         <bodydiv outputclass="col">
           <section outputclass="card w-50">
             <title outputclass="h5">Card Title</title>
-            <image outputclass="card-img-top" scope="external" href="https://picsum.photos/400/240?a"/>
+            <image outputclass="card-img-top" scope="external" href="https://picsum.photos/400/200?a"/>
             <p>Some quick example text to build on the card title and make up the bulk of the card’s content.</p>
             <xref outputclass="btn-primary" href="#">Go Somewhere</xref>
           </section>
@@ -107,7 +107,7 @@
       <bodydiv outputclass="row">
         <bodydiv outputclass="col">
           <section outputclass="card w-50">
-            <image outputclass="card-img-top" scope="external" href="https://picsum.photos/400/240?a"/>
+            <image outputclass="card-img-top" scope="external" href="https://picsum.photos/400/200?a"/>
             <p>Some quick example text to build on the card title and make up the bulk of the card’s content.</p>
           </section>
         </bodydiv>

--- a/sample/card.dita
+++ b/sample/card.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="cards">
@@ -37,12 +37,12 @@
       <p>Cards are built with as little markup and styles as possible, but still manage to deliver a ton of control and
         customization. Built with flexbox, they offer easy alignment and mix well with other Bootstrap components. They
         have no <xmlatt>margin</xmlatt> by default, so use
-        <xref href="https://getbootstrap.com/docs/5.1/utilities/spacing/" format="html" scope="external">spacing
+        <xref href="https://getbootstrap.com/docs/5.2/utilities/spacing/" format="html" scope="external">spacing
           utilities</xref> as needed.</p>
       <p>Below is an example of a basic card with mixed content and a fixed width. Cards have no fixed width to start,
         so they’ll naturally fill the full width of its parent element. This is easily customized with Bootstrap’s
         various
-        <xref href="https://getbootstrap.com/docs/5.1/components/card/#sizing" format="html" scope="external">sizing
+        <xref href="https://getbootstrap.com/docs/5.2/components/card/#sizing" format="html" scope="external">sizing
           options.</xref>
       </p>
     </section>

--- a/sample/carousel.dita
+++ b/sample/carousel.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="carousel">

--- a/sample/collapse.dita
+++ b/sample/collapse.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="collapse">

--- a/sample/figures.dita
+++ b/sample/figures.dita
@@ -6,7 +6,7 @@
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="figures">

--- a/sample/grid.dita
+++ b/sample/grid.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="grid">

--- a/sample/icons.dita
+++ b/sample/icons.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="icons">

--- a/sample/images.dita
+++ b/sample/images.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="images">
@@ -39,7 +39,7 @@
     <section>
       <title>Image thumbnails</title>
       <p>In addition to Bootstrap’s
-        <xref href="https://getbootstrap.com/docs/5.1/utilities/borders/" format="html" scope="external">border-radius
+        <xref href="https://getbootstrap.com/docs/5.2/utilities/borders/" format="html" scope="external">border-radius
           utilities</xref>, you can set <xmlatt>outputclass</xmlatt> to <codeph>img-thumbnail</codeph> to give an image
         a rounded 1px border appearance.</p>
     </section>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="index">
@@ -15,10 +15,10 @@
     <shortdesc>A plug-in for
       <xref href="http://www.dita-ot.org" format="html" scope="external">DITA Open Toolkit</xref> that extends the
       default HTML5 output with a
-      <xref href="https://getbootstrap.com/docs/5.1" format="html" scope="external">Bootstrap 5.1</xref> template and
+      <xref href="https://getbootstrap.com/docs/5.2" format="html" scope="external">Bootstrap 5.2</xref> template and
       components.</shortdesc>
     <p>Where necessary, the texts describing the usage of each component have been copied directly from the
-      <xref href="https://getbootstrap.com/docs/5.1" format="html" scope="external">official Bootstrap 5.1
+      <xref href="https://getbootstrap.com/docs/5.2" format="html" scope="external">official Bootstrap 5.2
         documentation</xref>, however DITA markup is used throughout the examples describing how to implement these
       components correctly using the DITA <xmlatt>outputclass</xmlatt> attribute. This text is therefore a derivative of
         <cite>Bootstrap 5 docs</cite> by Twitter, Inc. and the Bootstrap Authors, and used under
@@ -27,7 +27,7 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>Bootstrap 5.1</indexterm>
+        <indexterm>Bootstrap 5.2</indexterm>
         <indexterm>DITA</indexterm>
         <indexterm>installing</indexterm>
       </keywords>
@@ -64,7 +64,7 @@
       <p>The plug-in includes a default static navigation menu with a project name and global link placeholders.</p>
       <p>The default header file <filepath>includes/bs-navbar-default.hdr.xml</filepath> uses the Bootstrap primary
         (blue) background color for the
-        <xref href="https://getbootstrap.com/docs/5.1/examples/navbars/" format="html" scope="external">navbar
+        <xref href="https://getbootstrap.com/docs/5.2/examples/navbars/" format="html" scope="external">navbar
           component</xref>.</p>
       <p>You can edit a copy of this file to adjust the content of the global navigation. To override the global
         navigation with your own header, pass a custom header file to the <cmdname>dita</cmdname> command via the
@@ -110,15 +110,15 @@
         contents entirely.</p>
       <p>As of version 5.3.1, the plug-in provides five new options to style the table of contents navigation with the
         Bootstrap
-        <xref href="https://getbootstrap.com/docs/5.1/components/list-group/" format="html" scope="external">list
+        <xref href="https://getbootstrap.com/docs/5.2/components/list-group/" format="html" scope="external">list
           group</xref> component,
         <xref
-          href="https://getbootstrap.com/docs/5.1/components/navs-tabs/#pills"
+          href="https://getbootstrap.com/docs/5.2/components/navs-tabs/#pills"
           format="html"
           scope="external"
         >nav-pills</xref> and
          <xref
-          href="https://getbootstrap.com/docs/5.1/components/collapse/"
+          href="https://getbootstrap.com/docs/5.2/components/collapse/"
           format="html"
           scope="external"
         >collapsible</xref> menus.
@@ -258,14 +258,14 @@
       <indexterm><parmname>--bootstrap.css.dd</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.nav.parent</parmname></indexterm>
       <p>The HTML output for the following DITA elements can be annotated with common Bootstrap utility classes for
-        <xref href="https://getbootstrap.com/docs/5.1/utilities/borders" format="html" scope="external">borders</xref>,
+        <xref href="https://getbootstrap.com/docs/5.2/utilities/borders" format="html" scope="external">borders</xref>,
         <xref
-          href="https://getbootstrap.com/docs/5.1/utilities/background"
+          href="https://getbootstrap.com/docs/5.2/utilities/background"
           format="html"
           scope="external"
         >background</xref>,
-        <xref href="https://getbootstrap.com/docs/5.1/utilities/text" format="html" scope="external">text</xref>,
-        <xref href="https://getbootstrap.com/docs/5.1/utilities/spacing" format="html" scope="external">spacing</xref>,
+        <xref href="https://getbootstrap.com/docs/5.2/utilities/text" format="html" scope="external">text</xref>,
+        <xref href="https://getbootstrap.com/docs/5.2/utilities/spacing" format="html" scope="external">spacing</xref>,
         etc. using additional command line parameters:</p>
       <ul>
         <li>

--- a/sample/list-group.dita
+++ b/sample/list-group.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="list-group">

--- a/sample/offcanvas.dita
+++ b/sample/offcanvas.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="offcanvas">

--- a/sample/offcanvas.dita
+++ b/sample/offcanvas.dita
@@ -102,10 +102,15 @@
 &lt;section&gt;</codeblock>
     <section>
       <title>Responsive</title>
-      <p>Responsive offcanvas outputclasses hide content outside the viewport from a specified breakpoint and down. Above that breakpoint, the contents within will behave as usual. For example, <xmlatt>outputclass="offcanvas-lg"</xmlatt> hides content in an offcanvas below the <codeph>lg</codeph> breakpoint, but shows the content above the <codeph>lg</codeph> breakpoint.</p>
+      <p
+      >Responsive offcanvas outputclasses hide content outside the viewport from a specified breakpoint and down. Above that breakpoint, the contents within will behave as usual. For example, <xmlatt
+        >outputclass="offcanvas-lg"</xmlatt> hides content in an offcanvas below the <codeph
+        >lg</codeph> breakpoint, but shows the content above the <codeph>lg</codeph> breakpoint.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
-      <note outputclass="alert-info d-none d-lg-block">Resize your browser to show the responsive offcanvas toggle.</note>
+      <note
+        outputclass="alert-info d-none d-lg-block"
+      >Resize your browser to show the responsive offcanvas toggle.</note>
       <xref outputclass="btn-primary d-lg-none" props="offcanvas-toggle" href="#offcanvas4">Toggle offcanvas</xref>
       <section outputclass="offcanvas-lg" id="offcanvas4">
         <title>Offcanvas</title>

--- a/sample/offcanvas.dita
+++ b/sample/offcanvas.dita
@@ -70,11 +70,13 @@
       <p>There’s no default placement for offcanvas components, so you must add one of the modifier outputclasses
         below</p>
       <ul>
-        <li>Setting <xmlatt>outputclass</xmlatt> to <codeph>offcanvas-start</codeph> places offcanvas on the left of the
+        <li>Setting <xmlatt>outputclass="offcanvas-start"</xmlatt> places offcanvas on the left of the
           viewport (shown above)</li>
-        <li>Setting <xmlatt>outputclass</xmlatt> to <codeph>offcanvas-end</codeph> places offcanvas on the right of the
+        <li>Setting <xmlatt>outputclass="offcanvas-end"</xmlatt> places offcanvas on the right of the
           viewport</li>
-        <li>Setting <xmlatt>outputclass</xmlatt> to <codeph>offcanvas-bottom</codeph> places offcanvas on the bottom of
+        <li>Setting <xmlatt>outputclass="offcanvas-bottom"</xmlatt> places offcanvas on the bottom of
+          the viewport</li>
+        <li>Setting <xmlatt>outputclass="offcanvas-top"</xmlatt> places offcanvas on the top of
           the viewport</li>
       </ul>
     </section>
@@ -98,5 +100,38 @@
     <codeblock>&lt;section outputclass="offcanvas-bottom"&gt;
   ...etc
 &lt;section&gt;</codeblock>
+    <section>
+      <title>Responsive</title>
+      <p>Responsive offcanvas outputclasses hide content outside the viewport from a specified breakpoint and down. Above that breakpoint, the contents within will behave as usual. For example, <xmlatt>outputclass="offcanvas-lg"</xmlatt> hides content in an offcanvas below the <codeph>lg</codeph> breakpoint, but shows the content above the <codeph>lg</codeph> breakpoint.</p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <note outputclass="alert-info d-none d-lg-block">Resize your browser to show the responsive offcanvas toggle.</note>
+      <xref outputclass="btn-primary d-lg-none" props="offcanvas-toggle" href="#offcanvas4">Toggle offcanvas</xref>
+      <section outputclass="offcanvas-lg" id="offcanvas4">
+        <title>Offcanvas</title>
+        <p>This is content within an <xmlatt>outputclass="offcanvas-lg"</xmlatt>.</p>
+      </section>
+    </bodydiv>
+    <p>Responsive offcanvas classes are available across for each breakpoint.</p>
+    <ul>
+      <li><xmlatt>outputclass="offcanvas"</xmlatt></li>
+      <li><xmlatt>outputclass="offcanvas-sm"</xmlatt></li>
+      <li><xmlatt>outputclass="offcanvas-md"</xmlatt></li>
+      <li><xmlatt>outputclass="offcanvas-lg"</xmlatt></li>
+      <li><xmlatt>outputclass="offcanvas-xl"</xmlatt></li>
+      <li><xmlatt>outputclass="offcanvas-xxl"</xmlatt></li>
+    </ul>
+    <codeblock>&lt;note outputclass="alert-info d-none d-lg-block"&gt;
+  Resize your browser to show the responsive offcanvas toggle.
+&lt;/note&gt;
+&lt;xref outputclass="btn-primary d-lg-none" props="offcanvas-toggle" href="#offcanvas4"&gt;
+  Toggle offcanvas
+&lt;/xref&gt;
+&lt;section outputclass="offcanvas-lg" id="offcanvas4"&gt;
+  &lt;title&gt;Offcanvas&lt;/title&gt;
+  &lt;p&gt;
+    This is content within an &lt;xmlatt&gt;outputclass="offcanvas-lg"&lt;/xmlatt&gt;.
+  &lt;/p&gt;
+&lt;/section&gt;</codeblock>
   </body>
 </topic>

--- a/sample/pagination.dita
+++ b/sample/pagination.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="pagination">
@@ -141,7 +141,7 @@
       <title>Alignment</title>
       <p>Change the alignment of pagination component by appending Bootstrap
         <xref
-          href="https://getbootstrap.com/docs/5.1/utilities/flex/"
+          href="https://getbootstrap.com/docs/5.2/utilities/flex/"
           format="html"
           scope="external"
         >flexbox utility</xref> classes

--- a/sample/popovers.dita
+++ b/sample/popovers.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="popovers">

--- a/sample/popovers.dita
+++ b/sample/popovers.dita
@@ -98,7 +98,8 @@
     <section>
       <title>Custom popovers</title>
       <p>You can customize the appearance of popovers using CSS variables.
-        We set a custom class with <codeph>&lt;data name="class"&gt;custom-popover&lt;data&gt;</codeph> to scope our custom
+        We set a custom class with <codeph
+        >&lt;data name="class"&gt;custom-popover&lt;data&gt;</codeph> to scope our custom
         appearance and use it to override some of the local CSS variables.</p>
       <codeblock outputclass="language-css">.custom-popover {
   --bs-popover-max-width: 200px;

--- a/sample/popovers.dita
+++ b/sample/popovers.dita
@@ -53,15 +53,11 @@
 
     <bodydiv outputclass="bd-example" deliveryTarget="html">
       <xref href="#" outputclass="btn-lg btn-danger popover-top">
-        <data>
-          <title>Popover title</title>
-        </data>
+        <data name="title">Popover title</data>
         <desc>And here's some amazing content. It's very engaging. Right?</desc> Click to toggle popover </xref>
     </bodydiv>
     <codeblock> &lt;xref href="#" outputclass="btn-lg btn-danger popover-top"&gt;
-  &lt;data&gt;
-    &lt;title&gt;Popover title&lt;/title&gt;
-  &lt;/data&gt;
+  &lt;data name="title">&gt;Popover title&lt;/data&gt;
   &lt;desc&gt;And here's some amazing content. It's very engaging. Right?&lt;/desc&gt;
   Click to toggle popover
 &lt;/xref&gt;</codeblock>
@@ -98,6 +94,32 @@
 &lt;xref href="#" outputclass="btn-secondary popover-left"&gt;
   &lt;desc&gt;Left popover&lt;/desc&gt;
   Popover on left
+&lt;/xref&gt;</codeblock>
+    <section>
+      <title>Custom popovers</title>
+      <p>You can customize the appearance of popovers using CSS variables.
+        We set a custom class with <codeph>&lt;data name="class"&gt;custom-popover&lt;data&gt;</codeph> to scope our custom
+        appearance and use it to override some of the local CSS variables.</p>
+      <codeblock outputclass="language-css">.custom-popover {
+  --bs-popover-max-width: 200px;
+  --bs-popover-border-color: var(--bs-primary);
+  --bs-popover-header-bg: var(--bs-primary);
+  --bs-popover-header-color: var(--bs-white);
+  --bs-popover-body-padding-x: 1rem;
+  --bs-popover-body-padding-y: .5rem;
+}</codeblock>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+        <xref href="#" outputclass="btn-lg btn-danger popover-top">
+          <data name="title">Popover title</data>
+          <data name="class">custom-popover</data>
+          <desc>And here's some amazing content. It's very engaging. Right?</desc>Custom popover</xref>
+    </bodydiv>
+    <codeblock>&lt;xref href="#" outputclass="btn-lg btn-danger popover-top"&gt;
+  &lt;data name="title"&gt;Popover title&lt;/data&gt;
+  &lt;data name="class"&gt;custom-popover&lt;/data&gt;
+  &lt;desc&gt;And here's some amazing content. It's very engaging. Right?&lt;/desc&gt;
+  Custom popover
 &lt;/xref&gt;</codeblock>
   </body>
 </topic>

--- a/sample/scrollspy.dita
+++ b/sample/scrollspy.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass. -->
 <topic id="scrollspy">

--- a/sample/tables.dita
+++ b/sample/tables.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="tables">

--- a/sample/tables.dita
+++ b/sample/tables.dita
@@ -252,7 +252,8 @@
 &lt;/table&gt;</codeblock>
     <section>
       <title>Bordered tables</title>
-      <p>Add <xmlatt>rowsep="1"</xmlatt> and <xmlatt>colsep="1"</xmlatt> for borders on all sides of the table and cells.</p>
+      <p>Add <xmlatt>rowsep="1"</xmlatt> and <xmlatt
+        >colsep="1"</xmlatt> for borders on all sides of the table and cells.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
       <table rowsep="1" colsep="1">

--- a/sample/tables.dita
+++ b/sample/tables.dita
@@ -406,6 +406,79 @@
   ...etc
 &lt;/table&gt;</codeblock>
     <section>
+      <title>Vertical alignment</title>
+      <p>Table cells of <xmlelement>thead</xmlelement> are always vertical aligned to the bottom. Table cells in <xmlelement>tbody</xmlelement> inherit their alignment from <xmlelement>table</xmlelement> and are aligned to the top by default. Use the <xmlatt>valign</xmlatt> attribute to re-align where needed.</p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <table outputclass="align-middle">
+        <tgroup cols="4">
+          <colspec colname="COLSPEC0"/>
+          <colspec colname="COLSPEC1"/>
+          <colspec colname="COLSPEC2"/>
+          <colspec colname="COLSPEC3"/>
+          <thead>
+            <row>
+              <entry colname="COLSPEC0" valign="top">Heading 1</entry>
+              <entry colname="COLSPEC1" valign="bottom">Heading 2</entry>
+              <entry colname="COLSPEC2" valign="middle">Heading 3</entry>
+              <entry colname="COLSPEC3">Heading 4 - here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the headers</entry>
+            </row>
+          </thead>
+
+          <tbody>
+            <row>
+              <entry>This cell inherits <xmlatt>outputclass="align-middle"</xmlatt> from the table</entry>
+              <entry>This cell inherits <xmlatt>outputclass="align-middle"</xmlatt> from the table</entry>
+              <entry>This cell inherits <xmlatt>outputclass="align-middle"</xmlatt> from the table</entry>
+              <entry>This here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the preceding cells.</entry>
+            </row>
+            <row valign="bottom">
+              <entry>This cell inherits <xmlatt>valign="bottom"</xmlatt> from the table row</entry>
+              <entry>This cell inherits <xmlatt>valign="bottom"</xmlatt> from the table row</entry>
+              <entry>This cell inherits <xmlatt>valign="bottom"</xmlatt> from the table row</entry>
+              <entry>This here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the preceding cells.</entry>
+            </row>
+            <row>
+              <entry>This cell inherits <xmlatt>outputclass="align-middle"</xmlatt> from the table</entry>
+              <entry>This cell inherits <xmlatt>outputclass="align-middle"</xmlatt> from the table</entry>
+              <entry valign="top">This cell is aligned to the top.</entry>
+              <entry>This here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the preceding cells.</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </bodydiv>
+    <codeblock>&lt;table outputclass="align-middle"&gt;
+  &lt;tgroup cols="4"&gt;
+    &lt;colspec colname="COLSPEC0"/&gt;
+    &lt;colspec colname="COLSPEC1"/&gt;
+    &lt;colspec colname="COLSPEC2"/&gt;
+    &lt;colspec colname="COLSPEC3"/&gt;
+    &lt;thead&gt;
+      &lt;row&gt;
+        &lt;entry colname="COLSPEC0" valign="top"&gt;...&lt;/entry&gt;
+        &lt;entry colname="COLSPEC1" valign="bottom"&gt;...&lt;/entry&gt;
+        &lt;entry colname="COLSPEC2" valign="middle"&gt;...&lt;/entry&gt;
+        &lt;entry colname="COLSPEC3" valign="middle"&gt;...&lt;/entry&gt;
+      &lt;/row&gt;
+    &lt;/thead&gt;
+    &lt;tbody&gt;
+      &lt;row&gt;
+        ...
+      &lt;/row&gt;
+      &lt;row valign="bottom"&gt;
+        ...
+      &lt;/row&gt;
+      &lt;row&gt;
+        &lt;entry&gt;...&lt;/entry&gt;
+        &lt;entry&gt;...&lt;/entry&gt;
+        &lt;entry valign="top"&gt;...&lt;/entry&gt;
+        &lt;entry&gt;...&lt;/entry&gt;
+      &lt;/row&gt;
+    &lt;/tbody&gt;
+  &lt;/tgroup&gt;
+&lt;/table&gt;</codeblock>
+    <section>
       <title>Table head</title>
       <p>Similar to tables and dark tables, use the modifier <xmlatt>outputclass="table-light"</xmlatt> or
           <xmlatt>outputclass="table-dark"</xmlatt> to make <xmlelement>thead</xmlelement> elements appear light or dark

--- a/sample/tables.dita
+++ b/sample/tables.dita
@@ -252,10 +252,10 @@
 &lt;/table&gt;</codeblock>
     <section>
       <title>Bordered tables</title>
-      <p>Add <xmlatt>frame="all"</xmlatt> for borders on all sides of the table and cells.</p>
+      <p>Add <xmlatt>rowsep="1"</xmlatt> and <xmlatt>colsep="1"</xmlatt> for borders on all sides of the table and cells.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
-      <table frame="all">
+      <table rowsep="1" colsep="1">
         <tgroup cols="2">
           <colspec colname="COLSPEC0"/>
           <colspec colname="COLSPEC1"/>
@@ -286,15 +286,15 @@
         </tgroup>
       </table>
     </bodydiv>
-    <codeblock>&lt;table frame="all"&gt;
+    <codeblock>&lt;table rowsep="1" colsep="1"&gt;
   ...etc
 &lt;/table&gt;</codeblock>
     <section>
       <title>Tables without borders</title>
-      <p>Add <xmlatt>frame="none"</xmlatt> for a table without borders.</p>
+      <p>Add <xmlatt>rowsep="0"</xmlatt> and <xmlatt>colsep="0"</xmlatt> for a table without borders.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
-      <table frame="none">
+      <table rowsep="0" colsep="0">
         <tgroup cols="2">
           <colspec colname="COLSPEC0"/>
           <colspec colname="COLSPEC1"/>
@@ -325,7 +325,7 @@
         </tgroup>
       </table>
     </bodydiv>
-    <codeblock>&lt;table frame="none"&gt;
+    <codeblock>&lt;table rowsep="0" colsep="0"&gt;
   ...etc
 &lt;/table&gt;</codeblock>
     <section>

--- a/sample/tables.dita
+++ b/sample/tables.dita
@@ -210,6 +210,46 @@
   ...etc
 &lt;/table&gt;</codeblock>
     <section>
+      <title>Striped columns</title>
+      <p>Use <xmlatt>outputclass</xmlatt> and add <codeph>table-striped-columns</codeph> to add zebra-striping to any table row
+        within the <xmlelement>tbody</xmlelement>.</p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <table outputclass="table-striped-columns">
+        <tgroup cols="2">
+          <colspec colname="COLSPEC0"/>
+          <colspec colname="COLSPEC1"/>
+          <thead>
+            <row>
+              <entry colname="COLSPEC0" valign="top">Animal</entry>
+              <entry colname="COLSPEC1" valign="top">Gestation</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry>Elephant (African and Asian)</entry>
+              <entry>19-22 months</entry>
+            </row>
+            <row>
+              <entry>Giraffe</entry>
+              <entry>15 months</entry>
+            </row>
+            <row>
+              <entry>Rhinoceros</entry>
+              <entry>14-16 months</entry>
+            </row>
+            <row>
+              <entry>Hippopotamus</entry>
+              <entry>7 1/2 months</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </bodydiv>
+    <codeblock>&lt;table outputclass="table-striped-columns"&gt;
+  ...etc
+&lt;/table&gt;</codeblock>
+    <section>
       <title>Bordered tables</title>
       <p>Add <xmlatt>frame="all"</xmlatt> for borders on all sides of the table and cells.</p>
     </section>
@@ -288,12 +328,89 @@
   ...etc
 &lt;/table&gt;</codeblock>
     <section>
+      <title>Small Tables</title>
+      <p>Add <xmlatt>outputclass="table-sm"</xmlatt> make any table more compact by cutting all cell <codeph>padding</codeph> in half.</p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <table outputclass="table-sm">
+        <tgroup cols="2">
+          <colspec colname="COLSPEC0"/>
+          <colspec colname="COLSPEC1"/>
+          <thead>
+            <row>
+              <entry colname="COLSPEC0" valign="top">Animal</entry>
+              <entry colname="COLSPEC1" valign="top">Gestation</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry>Elephant (African and Asian)</entry>
+              <entry>19-22 months</entry>
+            </row>
+            <row>
+              <entry>Giraffe</entry>
+              <entry>15 months</entry>
+            </row>
+            <row>
+              <entry>Rhinoceros</entry>
+              <entry>14-16 months</entry>
+            </row>
+            <row>
+              <entry>Hippopotamus</entry>
+              <entry>7 1/2 months</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </bodydiv>
+    <codeblock>&lt;table outputclass="table-sm"&gt;
+  ...etc
+&lt;/table&gt;</codeblock>
+    <section>
+      <title>Table group dividers</title>
+      <p>Add a thicker border, darker between table groups—<xmlelement>thead</xmlelement> and <xmlelement>tbody</xmlelement>, with <xmlatt>outputclass="table-group-divider"</xmlatt>.</p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <table>
+        <tgroup cols="2">
+          <colspec colname="COLSPEC0"/>
+          <colspec colname="COLSPEC1"/>
+          <thead>
+            <row>
+              <entry colname="COLSPEC0" valign="top">Animal</entry>
+              <entry colname="COLSPEC1" valign="top">Gestation</entry>
+            </row>
+          </thead>
+          <tbody outputclass="table-group-divider">
+            <row>
+              <entry>Elephant (African and Asian)</entry>
+              <entry>19-22 months</entry>
+            </row>
+            <row>
+              <entry>Giraffe</entry>
+              <entry>15 months</entry>
+            </row>
+            <row>
+              <entry>Rhinoceros</entry>
+              <entry>14-16 months</entry>
+            </row>
+            <row>
+              <entry>Hippopotamus</entry>
+              <entry>7 1/2 months</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+    </bodydiv>
+    <codeblock>&lt;table outputclass="table-group-divider"&gt;
+  ...etc
+&lt;/table&gt;</codeblock>
+    <section>
       <title>Table head</title>
       <p>Similar to tables and dark tables, use the modifier <xmlatt>outputclass="table-light"</xmlatt> or
           <xmlatt>outputclass="table-dark"</xmlatt> to make <xmlelement>thead</xmlelement> elements appear light or dark
         gray.</p>
     </section>
-
     <bodydiv outputclass="bd-example" deliveryTarget="html">
       <table>
         <tgroup cols="2">

--- a/sample/tables.dita
+++ b/sample/tables.dita
@@ -211,7 +211,8 @@
 &lt;/table&gt;</codeblock>
     <section>
       <title>Striped columns</title>
-      <p>Use <xmlatt>outputclass</xmlatt> and add <codeph>table-striped-columns</codeph> to add zebra-striping to any table row
+      <p>Use <xmlatt>outputclass</xmlatt> and add <codeph
+        >table-striped-columns</codeph> to add zebra-striping to any table row
         within the <xmlelement>tbody</xmlelement>.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
@@ -329,7 +330,8 @@
 &lt;/table&gt;</codeblock>
     <section>
       <title>Small Tables</title>
-      <p>Add <xmlatt>outputclass="table-sm"</xmlatt> make any table more compact by cutting all cell <codeph>padding</codeph> in half.</p>
+      <p>Add <xmlatt>outputclass="table-sm"</xmlatt> make any table more compact by cutting all cell <codeph
+        >padding</codeph> in half.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
       <table outputclass="table-sm">
@@ -368,7 +370,8 @@
 &lt;/table&gt;</codeblock>
     <section>
       <title>Table group dividers</title>
-      <p>Add a thicker border, darker between table groups—<xmlelement>thead</xmlelement> and <xmlelement>tbody</xmlelement>, with <xmlatt>outputclass="table-group-divider"</xmlatt>.</p>
+      <p>Add a thicker border, darker between table groups—<xmlelement>thead</xmlelement> and <xmlelement
+        >tbody</xmlelement>, with <xmlatt>outputclass="table-group-divider"</xmlatt>.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
       <table>
@@ -407,7 +410,11 @@
 &lt;/table&gt;</codeblock>
     <section>
       <title>Vertical alignment</title>
-      <p>Table cells of <xmlelement>thead</xmlelement> are always vertical aligned to the bottom. Table cells in <xmlelement>tbody</xmlelement> inherit their alignment from <xmlelement>table</xmlelement> and are aligned to the top by default. Use the <xmlatt>valign</xmlatt> attribute to re-align where needed.</p>
+      <p>Table cells of <xmlelement
+        >thead</xmlelement> are always vertical aligned to the bottom. Table cells in <xmlelement
+        >tbody</xmlelement> inherit their alignment from <xmlelement
+        >table</xmlelement> and are aligned to the top by default. Use the <xmlatt
+        >valign</xmlatt> attribute to re-align where needed.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
       <table outputclass="align-middle">
@@ -421,7 +428,9 @@
               <entry colname="COLSPEC0" valign="top">Heading 1</entry>
               <entry colname="COLSPEC1" valign="bottom">Heading 2</entry>
               <entry colname="COLSPEC2" valign="middle">Heading 3</entry>
-              <entry colname="COLSPEC3">Heading 4 - here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the headers</entry>
+              <entry
+                colname="COLSPEC3"
+              >Heading 4 - here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the headers</entry>
             </row>
           </thead>
 
@@ -430,19 +439,22 @@
               <entry>This cell inherits <xmlatt>outputclass="align-middle"</xmlatt> from the table</entry>
               <entry>This cell inherits <xmlatt>outputclass="align-middle"</xmlatt> from the table</entry>
               <entry>This cell inherits <xmlatt>outputclass="align-middle"</xmlatt> from the table</entry>
-              <entry>This here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the preceding cells.</entry>
+              <entry
+              >This here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the preceding cells.</entry>
             </row>
             <row valign="bottom">
               <entry>This cell inherits <xmlatt>valign="bottom"</xmlatt> from the table row</entry>
               <entry>This cell inherits <xmlatt>valign="bottom"</xmlatt> from the table row</entry>
               <entry>This cell inherits <xmlatt>valign="bottom"</xmlatt> from the table row</entry>
-              <entry>This here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the preceding cells.</entry>
+              <entry
+              >This here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the preceding cells.</entry>
             </row>
             <row>
               <entry>This cell inherits <xmlatt>outputclass="align-middle"</xmlatt> from the table</entry>
               <entry>This cell inherits <xmlatt>outputclass="align-middle"</xmlatt> from the table</entry>
               <entry valign="top">This cell is aligned to the top.</entry>
-              <entry>This here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the preceding cells.</entry>
+              <entry
+              >This here is some placeholder text, intended to take up quite a bit of vertical space, to demonstrate how the vertical alignment works in the preceding cells.</entry>
             </row>
           </tbody>
         </tgroup>

--- a/sample/tabs.dita
+++ b/sample/tabs.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="tabs">

--- a/sample/tooltips.dita
+++ b/sample/tooltips.dita
@@ -101,7 +101,8 @@
 &lt;/xref&gt;</codeblock>
     <section>
       <title>Custom tooltips</title>
-      <p>You can customize the appearance of tooltips using CSS variables. We set a custom class with <codeph>&lt;data name="class"&gt;custom-tooltip&lt;data&gt;</codeph>  to scope our custom appearance and use it to override a local CSS variable.</p>
+      <p>You can customize the appearance of tooltips using CSS variables. We set a custom class with <codeph
+        >&lt;data name="class"&gt;custom-tooltip&lt;data&gt;</codeph>  to scope our custom appearance and use it to override a local CSS variable.</p>
     </section>
     <codeblock outputclass="language-css">.custom-tooltip {
   --bs-tooltip-bg: var(--bs-primary);

--- a/sample/tooltips.dita
+++ b/sample/tooltips.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="tooltips">

--- a/sample/tooltips.dita
+++ b/sample/tooltips.dita
@@ -99,5 +99,24 @@
   &lt;desc&gt;&lt;b&gt;Tooltip&lt;/b&gt; &lt;u&gt;with&amp;lt;/u&gt; &lt;b&gt;DITA&lt;/b&gt; elements&lt;/desc&gt;
   Tooltip with embedded DITA
 &lt;/xref&gt;</codeblock>
+    <section>
+      <title>Custom tooltips</title>
+      <p>You can customize the appearance of tooltips using CSS variables. We set a custom class with <codeph>&lt;data name="class"&gt;custom-tooltip&lt;data&gt;</codeph>  to scope our custom appearance and use it to override a local CSS variable.</p>
+    </section>
+    <codeblock outputclass="language-css">.custom-tooltip {
+  --bs-tooltip-bg: var(--bs-primary);
+}</codeblock>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <xref href="#" outputclass="btn-secondary tooltip-top">
+        <data name="class">custom-tooltip</data>
+        <desc>This top tooltip is themed via CSS variables.</desc>
+        Custom tooltip
+      </xref>
+    </bodydiv>
+    <codeblock>&lt;xref href="#" outputclass="btn-secondary tooltip-top"&gt;
+  &lt;data name="class"&gt;custom-tooltip&lt;/data&gt;
+  &lt;desc&gt;This top tooltip is themed via CSS variables.&lt;/desc&gt;
+  Custom tooltip
+&lt;/xref&gt;</codeblock>
   </body>
 </topic>

--- a/sample/typography.dita
+++ b/sample/typography.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass. -->
 <topic id="typography">

--- a/sample/utilities.dita
+++ b/sample/utilities.dita
@@ -74,9 +74,41 @@ Rough winds do shake the darling buds of May,
 and summer's lease hath all too short a date:
 ...</lines>
       <p/>
+      <table frame="all">
+        <tgroup cols="2">
+          <colspec colname="COLSPEC0"/>
+          <colspec colname="COLSPEC1"/>
+          <thead outputclass="table-dark">
+            <row>
+              <entry colname="COLSPEC0" valign="top">Animal</entry>
+              <entry colname="COLSPEC1" valign="top">Gestation</entry>
+            </row>
+          </thead>
+          <tbody>
+            <row>
+              <entry>Elephant (African and Asian)</entry>
+              <entry>19-22 months</entry>
+            </row>
+            <row>
+              <entry>Giraffe</entry>
+              <entry>15 months</entry>
+            </row>
+            <row>
+              <entry>Rhinoceros</entry>
+              <entry>14-16 months</entry>
+            </row>
+            <row>
+              <entry>Hippopotamus</entry>
+              <entry>7 1/2 months</entry>
+            </row>
+          </tbody>
+        </tgroup>
+      </table>
+      <p/>
     </bodydiv>
     <codeblock>&lt;codeblock frame="sides"&gt;...&lt;/codeblock&gt;
-&lt;lines frame="topbot" outputclass="bg-light"&gt;...&lt;/lines&gt;</codeblock>
+&lt;lines frame="topbot" outputclass="bg-light"&gt;...&lt;/lines&gt;
+&lt;table frame="all"&gt;...&lt;/table&gt;</codeblock>
     <section id="colors">
       <title>Colors</title>
       <p>Colorize text with color utilities</p>

--- a/sample/utilities.dita
+++ b/sample/utilities.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.1 documentation (found at https://getbootstrap.com/docs/5.1), however DITA
+   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.1 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0.
 
     -->


### PR DESCRIPTION
 Stable [bootstrap 5.2.0](https://blog.getbootstrap.com/2022/07/19/bootstrap-5-2-0/) has released.

- Update CDN library to latest version 5.2.0
- Updated docs to reference 5.2
- Update icons CDN to latest version 1.9.1