### PR TITLE
Outline collapse element on focus

### DIFF
--- a/css/collapsible-toc.css
+++ b/css/collapsible-toc.css
@@ -78,6 +78,11 @@
   transform: rotate(90deg);
 }
 
+.bd-links .btn:focus {
+  outline: 2px solid;
+  outline-color: var(--bs-link-hover-color);
+}
+
 .bd-links .active {
   font-weight: 600;
   color: var(--bs-body-color);


### PR DESCRIPTION
Updated CSS for a minor Accessibility improvement. When navigating a colllapsible nav using a keyboard, the arrow SVG should be outlined on focus

<img width="224" alt="Screenshot 2022-09-28 at 10 44 53" src="https://user-images.githubusercontent.com/3439249/192733464-72ee5f3d-20bc-4b17-bd9d-371e7cf30a89.png">

