### PR TITLE
Add open-graph metadata

### DIFF
--- a/.github/dita-ot/html.xml
+++ b/.github/dita-ot/html.xml
@@ -26,7 +26,10 @@
       <param name="processing-mode" value="strict"/>
       <param name="icons.include" value="yes"/>
       <param name="popovers.include" value="yes"/>
-      <param name="open-graph.url" value="https://infotexture.github.io/dita-bootstrap"/>
+      <param
+        name="open-graph.url"
+        value="https://infotexture.github.io/dita-bootstrap"
+      />
       <param name="twitter.site" value="@infotexture"/>
     </publication>
   </deliverable>

--- a/.github/dita-ot/html.xml
+++ b/.github/dita-ot/html.xml
@@ -26,6 +26,8 @@
       <param name="processing-mode" value="strict"/>
       <param name="icons.include" value="yes"/>
       <param name="popovers.include" value="yes"/>
+      <param name="open-graph.url" value="https://jason-fox.github.io/dita-bootstrap"/>
+      <param name="twitter.site" value="@infotexture"/>
     </publication>
   </deliverable>
 </project>

--- a/.github/dita-ot/html.xml
+++ b/.github/dita-ot/html.xml
@@ -26,7 +26,7 @@
       <param name="processing-mode" value="strict"/>
       <param name="icons.include" value="yes"/>
       <param name="popovers.include" value="yes"/>
-      <param name="open-graph.url" value="https://jason-fox.github.io/dita-bootstrap"/>
+      <param name="open-graph.url" value="https://infotexture.github.io/dita-bootstrap"/>
       <param name="twitter.site" value="@infotexture"/>
     </publication>
   </deliverable>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,9 @@ jobs:
           plugins: |
             fox.jason.extend.css
             https://github.com/infotexture/dita-bootstrap/archive/develop.zip
-            fox.jason.prismjs
+            https://github.com/jason-fox/fox.jason.prismjs/archive/master.zip
             fox.jason.favicon
+            https://github.com/jason-fox/fox.jason.open-graph/archive/master.zip
           project: .github/dita-ot/html.xml
       - name: Deploy HTML 🚀
         uses: JamesIves/github-pages-deploy-action@3.7.1


### PR DESCRIPTION
Use https://github.com/jason-fox/fox.jason.open-graph to add OpenGraph meta data to build

<img width="1062" alt="Screenshot 2022-12-13 at 11 51 31" src="https://user-images.githubusercontent.com/3439249/207299442-9140e4c9-fab9-4b44-9be7-4fbfcd7e666a.png">

Working example: https://jason-fox.github.io/dita-bootstrap/
See: https://opengraph.dev/panel?url=https%3A%2F%2Fjason-fox.github.io%2Fdita-bootstrap%2F
