### PR TITLE
Update Docs to bootstrap 5.3

### DIFF
--- a/.github/dita-ot/header.xml
+++ b/.github/dita-ot/header.xml
@@ -53,7 +53,7 @@
         <li class="nav-item">
           <a
             class="nav-link"
-            href="https://getbootstrap.com/docs/5.2"
+            href="https://getbootstrap.com/docs/5.3"
           >Bootstrap Docs</a>
         </li>
       </ul>

--- a/Customization/xsl/accordion.xsl
+++ b/Customization/xsl/accordion.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Accordion Component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/accordion/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/accordion/ -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'accordion')]">
     <div>

--- a/Customization/xsl/breadcrumb.xsl
+++ b/Customization/xsl/breadcrumb.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs dita-ot ditamsg"
 >
   <!-- Override to add Bootstrap breadcrumb component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/breadcrumb/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/breadcrumb/ -->
 
   <!-- Whether include a bootstrap breadcrumb component on each page.  values are 'yes' or 'no' -->
   <xsl:param name="BREADCRUMBS" select="'no'"/>

--- a/Customization/xsl/card.xsl
+++ b/Customization/xsl/card.xsl
@@ -12,7 +12,7 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 >
   <!-- Customization to add Bootstrap Card Component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/card/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/card/ -->
 
   <xsl:template match="*[contains(@class,' topic/section ') and contains(@outputclass, 'card')]">
     <div>
@@ -52,7 +52,7 @@
       <xsl:choose>
         <xsl:when
           test="count(preceding-sibling::*[contains(@class, ' topic/title ')]) > 0"
-        >sectiontitle card-subtitle text-muted</xsl:when>
+        >sectiontitle card-subtitle text-body-secondary</xsl:when>
         <xsl:otherwise>sectiontitle card-title</xsl:otherwise>
       </xsl:choose>
     </xsl:variable>

--- a/Customization/xsl/carousel.xsl
+++ b/Customization/xsl/carousel.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Carousel Component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/carousel/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/carousel/ -->
 
   <xsl:template
     match="*[ (contains(@class,' topic/ul ') or contains(@class, ' topic/ol ')) and contains(@outputclass, 'carousel')]"

--- a/Customization/xsl/collapse.xsl
+++ b/Customization/xsl/collapse.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Collapse Component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/collapse/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/collapse/ -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'collapse-horizontal')]">
     <xsl:variable name="id" select="if(@id) then dita-ot:generate-html-id(.) else generate-id(.)"/>

--- a/Customization/xsl/nav.xsl
+++ b/Customization/xsl/nav.xsl
@@ -209,7 +209,7 @@
   </xsl:template>
 
   <!-- list-group sidebar toc processing to add Bootstrap list-group menu -->
-  <!-- https://getbootstrap.com/docs/5.2/components/list-group/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/list-group/ -->
 
   <!-- partial list-group sidebar toc processing -->
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="list-group-toc-pull">
@@ -239,7 +239,7 @@
   </xsl:template>
 
   <!-- nav-pill sidebar toc processing to add Bootstrap nav-pills menu -->
-  <!-- https://getbootstrap.com/docs/5.2/components/navs-tabs/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/navs-tabs/ -->
 
   <!-- partial nav-pill sidebar toc processing -->
   <xsl:template match="*[contains(@class, ' map/map ')]" mode="nav-pill-toc-pull">
@@ -269,7 +269,7 @@
   </xsl:template>
 
   <!-- collapsible sidebar toc processing to add Bootstrap collapsing menu classes -->
-  <!-- https://getbootstrap.com/docs/5.2/components/collapse/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/collapse/ -->
   <xsl:template match="*" mode="collapsible-toc" priority="-10">
     <xsl:param name="pathFromMaplist" as="xs:string"/>
     <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="collapsible-toc">
@@ -278,7 +278,7 @@
   </xsl:template>
 
   <!-- nav-pill menubar-toc submenu toc processing - a navbar with dropdowns -->
-  <!-- https://getbootstrap.com/docs/5.2/components/dropdowns/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/dropdowns/ -->
   <xsl:template match="*" mode="menubar-toc" priority="-10">
     <xsl:param name="pathFromMaplist" as="xs:string"/>
     <xsl:apply-templates select="*[contains(@class, ' map/topicref ')]" mode="menubar-toc">

--- a/Customization/xsl/offcanvas.xsl
+++ b/Customization/xsl/offcanvas.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Offcanvas Component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/offcanvas/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/offcanvas/ -->
 
   <xsl:template match="*[contains(@class,' topic/section ') and contains(@outputclass, 'offcanvas-')]">
     <xsl:param name="headLevel">

--- a/Customization/xsl/pagination.xsl
+++ b/Customization/xsl/pagination.xsl
@@ -12,7 +12,7 @@
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 >
   <!-- Customization to add Bootstrap Pagination Component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/pagination/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/pagination/ -->
 
   <xsl:template
     match="*[ (contains(@class, ' topic/ol ') or contains(@class, ' topic/ul ')) and contains(@outputclass, 'pagination')]"

--- a/Customization/xsl/popovers.xsl
+++ b/Customization/xsl/popovers.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Popover component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/popovers/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/popovers/ -->
 
   <xsl:template match="*" mode="add-bootstrap-popover">
     <xsl:attribute name="data-bs-toggle">

--- a/Customization/xsl/scrollspy.xsl
+++ b/Customization/xsl/scrollspy.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Scrollspy Component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/scrollspy/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/scrollspy/ -->
 
   <xsl:template match="*" mode="scrollspy-href">
     <xsl:call-template name="scrollspy-href"/>

--- a/Customization/xsl/tabs.xsl
+++ b/Customization/xsl/tabs.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Tabbed Dialog Component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/navs-tabs/#tabs -->
+  <!-- https://getbootstrap.com/docs/5.3/components/navs-tabs/#tabs -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'nav-tabs')]">
     <ul role="tablist">
@@ -29,12 +29,12 @@
   </xsl:template>
 
   <!-- Customization to add Bootstrap Tabbed Dialog with Pills Component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/navs-tabs/#pills -->
+  <!-- https://getbootstrap.com/docs/5.3/components/navs-tabs/#pills -->
 
   <xsl:template match="*[contains(@class,' topic/bodydiv ') and contains(@outputclass, 'nav-pills')]">
     <xsl:choose>
       <!-- Pills with Vertical alignment -->
-      <!-- https://getbootstrap.com/docs/5.2/components/navs-tabs/#vertical -->
+      <!-- https://getbootstrap.com/docs/5.3/components/navs-tabs/#vertical -->
       <xsl:when test="contains(@outputclass, 'nav-pills-vertical')">
         <div class="d-flex align-items-start">
           <div role="tablist" aria-orientation="vertical">

--- a/Customization/xsl/tooltips.xsl
+++ b/Customization/xsl/tooltips.xsl
@@ -12,7 +12,7 @@
   exclude-result-prefixes="xs xhtml dita-ot"
 >
   <!-- Customization to add Bootstrap Tooltips component -->
-  <!-- https://getbootstrap.com/docs/5.2/components/tooltips/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/tooltips/ -->
 
   <xsl:template match="*" mode="add-bootstrap-tooltip">
     <xsl:attribute name="data-bs-toggle">

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -164,7 +164,7 @@
   </xsl:template>
 
   <!-- Override to add Bootstrap Alert classes and roles to Note elements -->
-  <!-- https://getbootstrap.com/docs/5.2/components/alerts/ -->
+  <!-- https://getbootstrap.com/docs/5.3/components/alerts/ -->
   <xsl:template match="*" mode="process.note.common-processing">
     <xsl:param name="type" select="@type"/>
     <xsl:param name="title">
@@ -207,7 +207,7 @@
   </xsl:template>
 
   <!-- Customization to add Bootstrap Figure Content -->
-  <!-- https://getbootstrap.com/docs/5.2/content/figures/ -->
+  <!-- https://getbootstrap.com/docs/5.3/content/figures/ -->
   <xsl:template
     match="*[contains(@class, ' topic/fig ') and not(contains(@class,' pr-d/syntaxdiagram '))]"
     name="topic.fig"
@@ -316,7 +316,7 @@
   </xsl:template>
 
   <!-- Customization to add Bootstrap Borders to Codeblock elements-->
-  <!-- https://getbootstrap.com/docs/5.2/utilities/borders/ -->
+  <!-- https://getbootstrap.com/docs/5.3/utilities/borders/ -->
   <xsl:template match="*[contains(@class, ' topic/pre ') and @frame]">
     <xsl:variable name="default-fig-class">
       <xsl:apply-templates select="." mode="dita2html:get-default-fig-class"/>
@@ -343,7 +343,7 @@
   </xsl:template>
 
   <!-- Customization to add Bootstrap Borders to Lines elements-->
-  <!-- https://getbootstrap.com/docs/5.2/utilities/borders/ -->
+  <!-- https://getbootstrap.com/docs/5.3/utilities/borders/ -->
   <xsl:template match="*[contains(@class, ' topic/lines ') and @frame]">
     <xsl:variable name="default-fig-class">
       <xsl:apply-templates select="." mode="dita2html:get-default-fig-class"/>

--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -10,7 +10,7 @@
   version="2.0"
   exclude-result-prefixes="xs dita-ot"
 >
-  <xsl:param name="BOOTSTRAP_CSS_SHORTDESC" select="'text-muted lead'"/>
+  <xsl:param name="BOOTSTRAP_CSS_SHORTDESC" select="'text-body-secondary lead'"/>
   <xsl:param name="BOOTSTRAP_CSS_CODEBLOCK" select="'border rounded'"/>
   <xsl:param name="BOOTSTRAP_CSS_TOPIC_TITLE" select="'text-dark'"/>
   <xsl:param name="BOOTSTRAP_CSS_SECTION_TITLE" select="'h4 text-secondary'"/>

--- a/README.md
+++ b/README.md
@@ -195,17 +195,17 @@ Breadcrumbs and menu bars can be added using the following parameters
 
 ## License
 
-[Apache 2.0](LICENSE) © 2017–2022 Roger W. Fienhold Sheen
+[Apache 2.0](LICENSE) © 2017–2023 Roger W. Fienhold Sheen
 
-Within the sample documentation, where necessary, the texts describing the usage of each component have been copied directly from the official [Bootstrap 5.2 documentation][2], however DITA markup is used throughout the examples describing how to implement these components correctly using `outputclass`. The text is therefore a derivative of "Bootstrap 5.2 docs" by Twitter, Inc. and the Bootstrap Authors, and used under CC BY 3.0.
+Within the sample documentation, where necessary, the texts describing the usage of each component have been copied directly from the official [Bootstrap 5.3 documentation][2], however DITA markup is used throughout the examples describing how to implement these components correctly using `outputclass`. The text is therefore a derivative of "Bootstrap 5.3 docs" by Twitter, Inc. and the Bootstrap Authors, and used under CC BY 3.0.
 
 [1]: http://www.dita-ot.org
-[2]: https://getbootstrap.com/docs/5.2
-[3]: https://getbootstrap.com/docs/5.2/examples/navbars/
+[2]: https://getbootstrap.com/docs/5.3
+[3]: https://getbootstrap.com/docs/5.3/examples/navbars/
 [4]: ./includes/bs-navbar-light.hdr.xml
 [5]: ./includes/bs-footer-example.xml
 [6]: https://www.dita-ot.org/dev/parameters/parameters-html5.html#html5__nav-toc
-[7]: https://getbootstrap.com/docs/5.2/components/list-group/
+[7]: https://getbootstrap.com/docs/5.3/components/list-group/
 [8]: https://infotexture.github.io/dita-bootstrap
 [9]: https://themestr.app/theme
 [10]: ./css/custom.css
@@ -214,5 +214,5 @@ Within the sample documentation, where necessary, the texts describing the usage
 [13]: https://twitter.com/infotexture
 [14]: https://github.com/infotexture/dita-bootstrap/issues/new
 [15]: https://help.github.com/articles/using-pull-requests/
-[16]: https://getbootstrap.com/docs/5.2/components/navs-tabs/#pills
-[17]: https://getbootstrap.com/docs/5.2/components/collapse/
+[16]: https://getbootstrap.com/docs/5.3/components/navs-tabs/#pills
+[17]: https://getbootstrap.com/docs/5.3/components/collapse/

--- a/css/custom.css
+++ b/css/custom.css
@@ -6812,7 +6812,7 @@ fieldset:disabled .btn {
   color: #212529 !important;
 }
 
-.text-muted {
+.text-body-secondary {
   color: #6c757d !important;
 }
 

--- a/includes/bootstrap.hdf.rtl.xml
+++ b/includes/bootstrap.hdf.rtl.xml
@@ -1,13 +1,11 @@
 <div>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap.rtl.min.css"
-    integrity="sha384-OXTEbYDqaX2ZY/BOaZV/yFGChYHtrXH2nyXJ372n2Y8abBhrqacCEe+3qhSHtLjy"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.rtl.min.css" integrity="sha384-WJUUqfoMmnfkBLne5uxXj+na/c7sesSJ32gI7GfCk4zO4GthUKhSEGyvQ839BC51"
     crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-u1OknCvxWvY5kfmNBILK2hRnQC3Pr17a+RTT6rIHI7NnikvbZlHgTPOOmMi466C8"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/bootstrap.hdf.rtl.xml
+++ b/includes/bootstrap.hdf.rtl.xml
@@ -1,11 +1,13 @@
 <div>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.rtl.min.css" integrity="sha384-WJUUqfoMmnfkBLne5uxXj+na/c7sesSJ32gI7GfCk4zO4GthUKhSEGyvQ839BC51"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.rtl.min.css"
+    integrity="sha384-WJUUqfoMmnfkBLne5uxXj+na/c7sesSJ32gI7GfCk4zO4GthUKhSEGyvQ839BC51"
     crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/bootstrap.hdf.xml
+++ b/includes/bootstrap.hdf.xml
@@ -2,9 +2,11 @@
  <link
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
     rel="stylesheet"
-    integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous"
+    integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD"
+    crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
+    crossorigin="anonymous"
   />
 </div>

--- a/includes/bootstrap.hdf.xml
+++ b/includes/bootstrap.hdf.xml
@@ -6,7 +6,8 @@
     crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/bootstrap.hdf.xml
+++ b/includes/bootstrap.hdf.xml
@@ -1,13 +1,10 @@
 <div>
-  <link
+ <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/css/bootstrap.min.css"
-    integrity="sha384-iYQeCzEYFbKjA/T2uDLTpkwGzCiq6soy8tYaI1GyVh/UjpbCx/TYkiZhlZB6+fzT"
-    crossorigin="anonymous"
+    integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.1/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-u1OknCvxWvY5kfmNBILK2hRnQC3Pr17a+RTT6rIHI7NnikvbZlHgTPOOmMi466C8"
-    crossorigin="anonymous"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js" integrity="sha384-w76AqPfDkMBDXo30jS1Sgez6pr3x5MlQ1ZAGC+nuZB+EYdgRZgiwxhTBTkF7CXvN" crossorigin="anonymous"
   />
 </div>

--- a/sample/accordion.dita
+++ b/sample/accordion.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="accordion">
@@ -29,7 +29,7 @@
       <title>How it works</title>
       <p>The accordion uses
         <xref
-          href="https://getbootstrap.com/docs/5.2/components/collapse/"
+          href="https://getbootstrap.com/docs/5.3/components/collapse/"
           format="html"
           scope="external"
         >collapse</xref> internally to make it collapsible. To render an accordion that’s expanded, add the class

--- a/sample/alerts.dita
+++ b/sample/alerts.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="alerts">

--- a/sample/badge.dita
+++ b/sample/badge.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="badges">

--- a/sample/breadcrumb.dita
+++ b/sample/breadcrumb.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="breadcrumb">

--- a/sample/button-group.dita
+++ b/sample/button-group.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="button-group">

--- a/sample/buttons.dita
+++ b/sample/buttons.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="buttons">

--- a/sample/card.dita
+++ b/sample/card.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="cards">
@@ -37,12 +37,12 @@
       <p>Cards are built with as little markup and styles as possible, but still manage to deliver a ton of control and
         customization. Built with flexbox, they offer easy alignment and mix well with other Bootstrap components. They
         have no <xmlatt>margin</xmlatt> by default, so use
-        <xref href="https://getbootstrap.com/docs/5.2/utilities/spacing/" format="html" scope="external">spacing
+        <xref href="https://getbootstrap.com/docs/5.3/utilities/spacing/" format="html" scope="external">spacing
           utilities</xref> as needed.</p>
       <p>Below is an example of a basic card with mixed content and a fixed width. Cards have no fixed width to start,
         so they’ll naturally fill the full width of its parent element. This is easily customized with Bootstrap’s
         various
-        <xref href="https://getbootstrap.com/docs/5.2/components/card/#sizing" format="html" scope="external">sizing
+        <xref href="https://getbootstrap.com/docs/5.3/components/card/#sizing" format="html" scope="external">sizing
           options.</xref>
       </p>
     </section>

--- a/sample/carousel.dita
+++ b/sample/carousel.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="carousel">

--- a/sample/collapse.dita
+++ b/sample/collapse.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="collapse">

--- a/sample/figures.dita
+++ b/sample/figures.dita
@@ -6,7 +6,7 @@
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="figures">

--- a/sample/grid.dita
+++ b/sample/grid.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="grid">

--- a/sample/icons.dita
+++ b/sample/icons.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="icons">

--- a/sample/images.dita
+++ b/sample/images.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="images">
@@ -39,7 +39,7 @@
     <section>
       <title>Image thumbnails</title>
       <p>In addition to Bootstrap’s
-        <xref href="https://getbootstrap.com/docs/5.2/utilities/borders/" format="html" scope="external">border-radius
+        <xref href="https://getbootstrap.com/docs/5.3/utilities/borders/" format="html" scope="external">border-radius
           utilities</xref>, you can set <xmlatt>outputclass</xmlatt> to <codeph>img-thumbnail</codeph> to give an image
         a rounded 1px border appearance.</p>
     </section>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="index">
@@ -15,10 +15,10 @@
     <shortdesc>A plug-in for
       <xref href="http://www.dita-ot.org" format="html" scope="external">DITA Open Toolkit</xref> that extends the
       default HTML5 output with a
-      <xref href="https://getbootstrap.com/docs/5.2" format="html" scope="external">Bootstrap 5.2</xref> template and
+      <xref href="https://getbootstrap.com/docs/5.3" format="html" scope="external">Bootstrap 5.3</xref> template and
       components.</shortdesc>
     <p>Where necessary, the texts describing the usage of each component have been copied directly from the
-      <xref href="https://getbootstrap.com/docs/5.2" format="html" scope="external">official Bootstrap 5.2
+      <xref href="https://getbootstrap.com/docs/5.3" format="html" scope="external">official Bootstrap 5.3
         documentation</xref>, however DITA markup is used throughout the examples describing how to implement these
       components correctly using the DITA <xmlatt>outputclass</xmlatt> attribute. This text is therefore a derivative of
         <cite>Bootstrap 5 docs</cite> by Twitter, Inc. and the Bootstrap Authors, and used under
@@ -27,7 +27,7 @@
   <prolog>
     <metadata>
       <keywords>
-        <indexterm>Bootstrap 5.2</indexterm>
+        <indexterm>Bootstrap 5.3</indexterm>
         <indexterm>DITA</indexterm>
         <indexterm>installing</indexterm>
       </keywords>
@@ -64,7 +64,7 @@
       <p>The plug-in includes a default static navigation menu with a project name and global link placeholders.</p>
       <p>The default header file <filepath>includes/bs-navbar-default.hdr.xml</filepath> uses the Bootstrap primary
         (blue) background color for the
-        <xref href="https://getbootstrap.com/docs/5.2/examples/navbars/" format="html" scope="external">navbar
+        <xref href="https://getbootstrap.com/docs/5.3/examples/navbars/" format="html" scope="external">navbar
           component</xref>.</p>
       <p>You can edit a copy of this file to adjust the content of the global navigation. To override the global
         navigation with your own header, pass a custom header file to the <cmdname>dita</cmdname> command via the
@@ -110,15 +110,15 @@
         contents entirely.</p>
       <p>As of version 5.3.1, the plug-in provides five new options to style the table of contents navigation with the
         Bootstrap
-        <xref href="https://getbootstrap.com/docs/5.2/components/list-group/" format="html" scope="external">list
+        <xref href="https://getbootstrap.com/docs/5.3/components/list-group/" format="html" scope="external">list
           group</xref> component,
         <xref
-          href="https://getbootstrap.com/docs/5.2/components/navs-tabs/#pills"
+          href="https://getbootstrap.com/docs/5.3/components/navs-tabs/#pills"
           format="html"
           scope="external"
         >nav-pills</xref> and
          <xref
-          href="https://getbootstrap.com/docs/5.2/components/collapse/"
+          href="https://getbootstrap.com/docs/5.3/components/collapse/"
           format="html"
           scope="external"
         >collapsible</xref> menus.
@@ -258,14 +258,14 @@
       <indexterm><parmname>--bootstrap.css.dd</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.nav.parent</parmname></indexterm>
       <p>The HTML output for the following DITA elements can be annotated with common Bootstrap utility classes for
-        <xref href="https://getbootstrap.com/docs/5.2/utilities/borders" format="html" scope="external">borders</xref>,
+        <xref href="https://getbootstrap.com/docs/5.3/utilities/borders" format="html" scope="external">borders</xref>,
         <xref
-          href="https://getbootstrap.com/docs/5.2/utilities/background"
+          href="https://getbootstrap.com/docs/5.3/utilities/background"
           format="html"
           scope="external"
         >background</xref>,
-        <xref href="https://getbootstrap.com/docs/5.2/utilities/text" format="html" scope="external">text</xref>,
-        <xref href="https://getbootstrap.com/docs/5.2/utilities/spacing" format="html" scope="external">spacing</xref>,
+        <xref href="https://getbootstrap.com/docs/5.3/utilities/text" format="html" scope="external">text</xref>,
+        <xref href="https://getbootstrap.com/docs/5.3/utilities/spacing" format="html" scope="external">spacing</xref>,
         etc. using additional command line parameters:</p>
       <ul>
         <li>

--- a/sample/list-group.dita
+++ b/sample/list-group.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="list-group">

--- a/sample/offcanvas.dita
+++ b/sample/offcanvas.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="offcanvas">

--- a/sample/pagination.dita
+++ b/sample/pagination.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="pagination">
@@ -141,7 +141,7 @@
       <title>Alignment</title>
       <p>Change the alignment of pagination component by appending Bootstrap
         <xref
-          href="https://getbootstrap.com/docs/5.2/utilities/flex/"
+          href="https://getbootstrap.com/docs/5.3/utilities/flex/"
           format="html"
           scope="external"
         >flexbox utility</xref> classes

--- a/sample/popovers.dita
+++ b/sample/popovers.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="popovers">

--- a/sample/rtl.dita
+++ b/sample/rtl.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="rtl">

--- a/sample/scrollspy.dita
+++ b/sample/scrollspy.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass. -->
 <topic id="scrollspy">

--- a/sample/tables.dita
+++ b/sample/tables.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="tables">

--- a/sample/tabs.dita
+++ b/sample/tabs.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="tabs">

--- a/sample/tooltips.dita
+++ b/sample/tooltips.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
    file for applicable licenses.-->
 <topic id="tooltips">

--- a/sample/typography.dita
+++ b/sample/typography.dita
@@ -2,7 +2,7 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass. -->
 <topic id="typography">
@@ -47,10 +47,10 @@
         heading text from Bootstrap 3.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
-      <p outputclass="h3">Fancy display heading <ph outputclass="small text-muted">with faded secondary text</ph></p>
+      <p outputclass="h3">Fancy display heading <ph outputclass="small text-body-secondary">with faded secondary text</ph></p>
     </bodydiv>
     <codeblock
-    >&lt;title&gt;Fancy display heading &lt;ph outputclass="small text-muted"&gt;with faded secondary text&lt;/ph&gt;&lt;/title&gt;</codeblock>
+    >&lt;title&gt;Fancy display heading &lt;ph outputclass="small text-body-secondary"&gt;with faded secondary text&lt;/ph&gt;&lt;/title&gt;</codeblock>
     <section>
       <title>Display headings</title>
       <p>Traditional heading elements are designed to work best in the meat of your page content. When you need a

--- a/sample/typography.dita
+++ b/sample/typography.dita
@@ -47,7 +47,9 @@
         heading text from Bootstrap 3.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
-      <p outputclass="h3">Fancy display heading <ph outputclass="small text-body-secondary">with faded secondary text</ph></p>
+      <p outputclass="h3">Fancy display heading <ph
+          outputclass="small text-body-secondary"
+        >with faded secondary text</ph></p>
     </bodydiv>
     <codeblock
     >&lt;title&gt;Fancy display heading &lt;ph outputclass="small text-body-secondary"&gt;with faded secondary text&lt;/ph&gt;&lt;/title&gt;</codeblock>

--- a/sample/utilities.dita
+++ b/sample/utilities.dita
@@ -2,11 +2,11 @@
 <!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
 <!-- Within the sample documentation, where necessary, the texts describing the
    usage of each component have been copied directly from the official Bootstrap
-   5.2 documentation (found at https://getbootstrap.com/docs/5.2), however DITA
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
    markup is used throughout the examples describing how to implement these
    components correctly using outputclass.
 
-   This work, is a derivative of "Bootstrap 5.2 docs" by Twitter, Inc.
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
    and the Bootstrap Authors, and used under CC BY 3.0.
 
     -->
@@ -115,31 +115,59 @@ and summer's lease hath all too short a date:
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
       <section outputclass="text-primary">.text-primary</section>
+      <section outputclass="text-primary-emphasis">.text-primary-emphasis</section>
       <section outputclass="text-secondary">.text-secondary</section>
+      <section outputclass="text-secondary-emphasis">.text-secondary-emphasis</section>
       <section outputclass="text-success">.text-success</section>
+      <section outputclass="text-success-emphasis">.text-success-emphasis</section>
       <section outputclass="text-danger">.text-danger</section>
+      <section outputclass="text-danger-emphasis">.text-danger-emphasis</section>
       <section outputclass="text-warning bg-dark">.text-warning</section>
+      <section outputclass="text-warning-emphasis">.text-warning-emphasis</section>
       <section outputclass="text-info bg-dark">.text-info</section>
+      <section outputclass="text-info-emphasis">.text-info-emphasis</section>
       <section outputclass="text-light bg-dark">.text-light</section>
-      <section outputclass="text-dark">.text-dark</section>
+      <section outputclass="text-light-emphasis">.text-light-emphasis</section>
+      <section outputclass="text-dark bg-white">.text-dark</section>
+      <section outputclass="text-dark-emphasis">.text-dark-emphasis</section>
       <section outputclass="text-body">.text-body</section>
       <section outputclass="text-muted">.text-muted</section>
+
+      <section outputclass="text-body-emphasis">.text-body-emphasis</section>
+      <section outputclass="text-body-secondary">.text-body-secondary</section>
+      <section outputclass="text-body-tertiary">.text-body-tertiary</section>
+
+      <section outputclass="text-black bg-white">.text-black</section>
       <section outputclass="text-white bg-dark">.text-white</section>
-      <section outputclass="text-black-50">.text-black-50</section>
+      <section outputclass="text-black-50 bg-white">.text-black-50</section>
       <section outputclass="text-white-50 bg-dark">.text-white-50</section>
     </bodydiv>
     <codeblock>&lt;section outputclass="text-primary"&gt;.text-primary&lt;/section&gt;
+&lt;section outputclass="text-primary-emphasis"&gt;.text-primary-emphasis&lt;/section&gt;
 &lt;section outputclass="text-secondary"&gt;.text-secondary&lt;/section&gt;
+&lt;section outputclass="text-secondary-emphasis"&gt;.text-secondary-emphasis&lt;/section&gt;
 &lt;section outputclass="text-success"&gt;.text-success&lt;/section&gt;
+&lt;section outputclass="text-success-emphasis"&gt;.text-success-emphasis&lt;/section&gt;
 &lt;section outputclass="text-danger"&gt;.text-danger&lt;/section&gt;
+&lt;section outputclass="text-danger-emphasis"&gt;.text-danger-emphasis&lt;/section&gt;
 &lt;section outputclass="text-warning bg-dark"&gt;.text-warning&lt;/section&gt;
+&lt;section outputclass="text-warning-emphasis"&gt;.text-warning-emphasis&lt;/section&gt;
 &lt;section outputclass="text-info bg-dark"&gt;.text-info&lt;/section&gt;
+&lt;section outputclass="text-info-emphasis"&gt;.text-info-emphasis&lt;/section&gt;
 &lt;section outputclass="text-light bg-dark"&gt;.text-light&lt;/section&gt;
-&lt;section outputclass="text-dark"&gt;.text-dark&lt;/section&gt;
+&lt;section outputclass="text-light-emphasis"&gt;.text-light-emphasis&lt;/section&gt;
+&lt;section outputclass="text-dark bg-white"&gt;.text-dark&lt;/section&gt;
+&lt;section outputclass="text-dark-emphasis"&gt;.text-dark-emphasis&lt;/section&gt;
 &lt;section outputclass="text-body"&gt;.text-body&lt;/section&gt;
 &lt;section outputclass="text-muted"&gt;.text-muted&lt;/section&gt;
+
+&lt;section outputclass="text-body-emphasis"&gt;.text-body-emphasis&lt;/section&gt;
+&lt;section outputclass="text-body-secondary"&gt;.text-body-secondary&lt;/section&gt;
+&lt;section outputclass="text-body-tertiary"&gt;.text-body-tertiary&lt;/section&gt;
+
+&lt;section outputclass="text-black bg-white"&gt;.text-black&lt;/section&gt;
 &lt;section outputclass="text-white bg-dark"&gt;.text-white&lt;/section&gt;
-&lt;section outputclass="text-black-50"&gt;.text-black-50&lt;/section&gt;
+&lt;section outputclass="text-black-50 bg-white"&gt;.text-black-50&lt;/section&gt;
 &lt;section outputclass="text-white-50 bg-dark"&gt;.text-white-50&lt;/section&gt;</codeblock>
     <section id="background-color">
       <title>Background color</title>
@@ -149,29 +177,53 @@ and summer's lease hath all too short a date:
         <xmlatt>outputclass</xmlatt> utilities.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
-      <section outputclass="p-3 bg-primary text-white">.bg-primary</section>
-      <section outputclass="p-3 bg-secondary text-white">.bg-secondary</section>
-      <section outputclass="p-3 bg-success text-white">.bg-success</section>
-      <section outputclass="p-3 bg-danger text-white">.bg-danger</section>
-      <section outputclass="p-3 bg-warning text-dark">.bg-warning</section>
-      <section outputclass="p-3 bg-info text-dark">.bg-info</section>
-      <section outputclass="p-3 bg-light text-dark">.bg-light</section>
-      <section outputclass="p-3 bg-dark text-white">.bg-dark</section>
-      <section outputclass="p-3 bg-body text-dark">.bg-body</section>
-      <section outputclass="p-3 bg-white text-dark">.bg-white</section>
-      <section outputclass="p-3 bg-transparent text-dark">.bg-transparent</section>
+      <section class="p-3 mb-2 bg-primary text-white">.bg-primary</section>
+      <section class="p-3 mb-2 bg-primary-subtle text-emphasis-primary">.bg-primary-subtle</section>
+      <section class="p-3 mb-2 bg-secondary text-white">.bg-secondary</section>
+      <section class="p-3 mb-2 bg-secondary-subtle text-emphasis-secondary">.bg-secondary-subtle</section>
+      <section class="p-3 mb-2 bg-success text-white">.bg-success</section>
+      <section class="p-3 mb-2 bg-success-subtle text-emphasis-success">.bg-success-subtle</section>
+      <section class="p-3 mb-2 bg-danger text-white">.bg-danger</section>
+      <section class="p-3 mb-2 bg-danger-subtle text-emphasis-danger">.bg-danger-subtle</section>
+      <section class="p-3 mb-2 bg-warning text-dark">.bg-warning</section>
+      <section class="p-3 mb-2 bg-warning-subtle text-emphasis-warning">.bg-warning-subtle</section>
+      <section class="p-3 mb-2 bg-info text-dark">.bg-info</section>
+      <section class="p-3 mb-2 bg-info-subtle text-emphasis-info">.bg-info-subtle</section>
+      <section class="p-3 mb-2 bg-light text-dark">.bg-light</section>
+      <section class="p-3 mb-2 bg-light-subtle text-emphasis-light">.bg-light-subtle</section>
+      <section class="p-3 mb-2 bg-dark text-white">.bg-dark</section>
+      <section class="p-3 mb-2 bg-dark-subtle text-emphasis-dark">.bg-dark-subtle</section>
+      <p class="p-3 mb-2 bg-body-secondary">.bg-body-secondary</p>
+      <p class="p-3 mb-2 bg-body-tertiary">.bg-body-tertiary</p>
+
+      <section class="p-3 mb-2 bg-body text-body">.bg-body</section>
+      <section class="p-3 mb-2 bg-black text-white">.bg-black</section>
+      <section class="p-3 mb-2 bg-white text-dark">.bg-white</section>
+      <section class="p-3 mb-2 bg-transparent text-body">.bg-transparent</section>
     </bodydiv>
-    <codeblock>&lt;section outputclass="p-3 bg-primary text-white"&gt;.bg-primary&lt;/section&gt;
-&lt;section outputclass="p-3 bg-secondary text-white"&gt;.bg-secondary&lt;/section&gt;
-&lt;section outputclass="p-3 bg-success text-white"&gt;.bg-success&lt;/section&gt;
-&lt;section outputclass="p-3 bg-danger text-white"&gt;.bg-danger&lt;/section&gt;
-&lt;section outputclass="p-3 bg-warning text-dark"&gt;.bg-warning&lt;/section&gt;
-&lt;section outputclass="p-3 bg-info text-dark"&gt;.bg-info&lt;/section&gt;
-&lt;section outputclass="p-3 bg-light text-dark"&gt;.bg-light&lt;/section&gt;
-&lt;section outputclass="p-3 bg-dark text-white"&gt;.bg-dark&lt;/section&gt;
-&lt;section outputclass="p-3 bg-body text-dark"&gt;.bg-body&lt;/section&gt;
-&lt;section outputclass="p-3 bg-white text-dark"&gt;.bg-white&lt;/section&gt;
-&lt;section outputclass="p-3 bg-transparent text-dark"&gt;.bg-transparent&lt;/section&gt;</codeblock>
+    <codeblock>&lt;section class="p-3 mb-2 bg-primary text-white"&gt;.bg-primary&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-primary-subtle text-emphasis-primary"&gt;.bg-primary-subtle&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-secondary text-white"&gt;.bg-secondary&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-secondary-subtle text-emphasis-secondary"&gt;.bg-secondary-subtle&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-success text-white"&gt;.bg-success&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-success-subtle text-emphasis-success"&gt;.bg-success-subtle&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-danger text-white"&gt;.bg-danger&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-danger-subtle text-emphasis-danger"&gt;.bg-danger-subtle&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-warning text-dark"&gt;.bg-warning&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-warning-subtle text-emphasis-warning"&gt;.bg-warning-subtle&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-info text-dark"&gt;.bg-info&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-info-subtle text-emphasis-info"&gt;.bg-info-subtle&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-light text-dark"&gt;.bg-light&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-light-subtle text-emphasis-light"&gt;.bg-light-subtle&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-dark text-white"&gt;.bg-dark&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-dark-subtle text-emphasis-dark"&gt;.bg-dark-subtle&lt;/section&gt;
+&lt;p class="p-3 mb-2 bg-body-secondary"&gt;.bg-body-secondary&lt;/p&gt;
+&lt;p class="p-3 mb-2 bg-body-tertiary"&gt;.bg-body-tertiary&lt;/p&gt;
+
+&lt;section class="p-3 mb-2 bg-body text-body"&gt;.bg-body&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-black text-white"&gt;.bg-black&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-white text-dark"&gt;.bg-white&lt;/section&gt;
+&lt;section class="p-3 mb-2 bg-transparent text-body"&gt;.bg-transparent&lt;/section&gt;</codeblock>
     <section>
       <title>Styling DITA elements</title>
       <p>Apply consistent Bootstrap utility classes across DITA elements by amending
@@ -184,7 +236,7 @@ and summer's lease hath all too short a date:
 &lt;/xsl:template&gt;
 &lt;!-- Enhance the short desc with a lead class --&gt;
 &lt;xsl:template match="*[contains(@class, ' topic/shortdesc ')]" mode="get-output-class"&gt;
-  text-muted lead
+  text-body-secondary lead
 &lt;/xsl:template&gt;
 &lt;!-- Change the text color of the headers --&gt;
 &lt;xsl:template match="*[contains(@class, ' topic/title ')]" mode="get-output-class"&gt;

--- a/sample/utilities.dita
+++ b/sample/utilities.dita
@@ -177,53 +177,53 @@ and summer's lease hath all too short a date:
         <xmlatt>outputclass</xmlatt> utilities.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
-      <section class="p-3 mb-2 bg-primary text-white">.bg-primary</section>
-      <section class="p-3 mb-2 bg-primary-subtle text-emphasis-primary">.bg-primary-subtle</section>
-      <section class="p-3 mb-2 bg-secondary text-white">.bg-secondary</section>
-      <section class="p-3 mb-2 bg-secondary-subtle text-emphasis-secondary">.bg-secondary-subtle</section>
-      <section class="p-3 mb-2 bg-success text-white">.bg-success</section>
-      <section class="p-3 mb-2 bg-success-subtle text-emphasis-success">.bg-success-subtle</section>
-      <section class="p-3 mb-2 bg-danger text-white">.bg-danger</section>
-      <section class="p-3 mb-2 bg-danger-subtle text-emphasis-danger">.bg-danger-subtle</section>
-      <section class="p-3 mb-2 bg-warning text-dark">.bg-warning</section>
-      <section class="p-3 mb-2 bg-warning-subtle text-emphasis-warning">.bg-warning-subtle</section>
-      <section class="p-3 mb-2 bg-info text-dark">.bg-info</section>
-      <section class="p-3 mb-2 bg-info-subtle text-emphasis-info">.bg-info-subtle</section>
-      <section class="p-3 mb-2 bg-light text-dark">.bg-light</section>
-      <section class="p-3 mb-2 bg-light-subtle text-emphasis-light">.bg-light-subtle</section>
-      <section class="p-3 mb-2 bg-dark text-white">.bg-dark</section>
-      <section class="p-3 mb-2 bg-dark-subtle text-emphasis-dark">.bg-dark-subtle</section>
-      <p class="p-3 mb-2 bg-body-secondary">.bg-body-secondary</p>
-      <p class="p-3 mb-2 bg-body-tertiary">.bg-body-tertiary</p>
+      <section outputclass="p-3 mb-2 bg-primary text-white">.bg-primary</section>
+      <section outputclass="p-3 mb-2 bg-primary-subtle text-emphasis-primary">.bg-primary-subtle</section>
+      <section outputclass="p-3 mb-2 bg-secondary text-white">.bg-secondary</section>
+      <section outputclass="p-3 mb-2 bg-secondary-subtle text-emphasis-secondary">.bg-secondary-subtle</section>
+      <section outputclass="p-3 mb-2 bg-success text-white">.bg-success</section>
+      <section outputclass="p-3 mb-2 bg-success-subtle text-emphasis-success">.bg-success-subtle</section>
+      <section outputclass="p-3 mb-2 bg-danger text-white">.bg-danger</section>
+      <section outputclass="p-3 mb-2 bg-danger-subtle text-emphasis-danger">.bg-danger-subtle</section>
+      <section outputclass="p-3 mb-2 bg-warning text-dark">.bg-warning</section>
+      <section outputclass="p-3 mb-2 bg-warning-subtle text-emphasis-warning">.bg-warning-subtle</section>
+      <section outputclass="p-3 mb-2 bg-info text-dark">.bg-info</section>
+      <section outputclass="p-3 mb-2 bg-info-subtle text-emphasis-info">.bg-info-subtle</section>
+      <section outputclass="p-3 mb-2 bg-light text-dark">.bg-light</section>
+      <section outputclass="p-3 mb-2 bg-light-subtle text-emphasis-light">.bg-light-subtle</section>
+      <section outputclass="p-3 mb-2 bg-dark text-white">.bg-dark</section>
+      <section outputclass="p-3 mb-2 bg-dark-subtle text-emphasis-dark">.bg-dark-subtle</section>
+      <section outputclass="p-3 mb-2 bg-body-secondary">.bg-body-secondary</section>
+      <section outputclass="p-3 mb-2 bg-body-tertiary">.bg-body-tertiary</section>
 
-      <section class="p-3 mb-2 bg-body text-body">.bg-body</section>
-      <section class="p-3 mb-2 bg-black text-white">.bg-black</section>
-      <section class="p-3 mb-2 bg-white text-dark">.bg-white</section>
-      <section class="p-3 mb-2 bg-transparent text-body">.bg-transparent</section>
+      <section outputclass="p-3 mb-2 bg-body text-body">.bg-body</section>
+      <section outputclass="p-3 mb-2 bg-black text-white">.bg-black</section>
+      <section outputclass="p-3 mb-2 bg-white text-dark">.bg-white</section>
+      <section outputclass="p-3 mb-2 bg-transparent text-body">.bg-transparent</section>
     </bodydiv>
-    <codeblock>&lt;section class="p-3 mb-2 bg-primary text-white"&gt;.bg-primary&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-primary-subtle text-emphasis-primary"&gt;.bg-primary-subtle&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-secondary text-white"&gt;.bg-secondary&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-secondary-subtle text-emphasis-secondary"&gt;.bg-secondary-subtle&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-success text-white"&gt;.bg-success&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-success-subtle text-emphasis-success"&gt;.bg-success-subtle&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-danger text-white"&gt;.bg-danger&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-danger-subtle text-emphasis-danger"&gt;.bg-danger-subtle&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-warning text-dark"&gt;.bg-warning&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-warning-subtle text-emphasis-warning"&gt;.bg-warning-subtle&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-info text-dark"&gt;.bg-info&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-info-subtle text-emphasis-info"&gt;.bg-info-subtle&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-light text-dark"&gt;.bg-light&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-light-subtle text-emphasis-light"&gt;.bg-light-subtle&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-dark text-white"&gt;.bg-dark&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-dark-subtle text-emphasis-dark"&gt;.bg-dark-subtle&lt;/section&gt;
-&lt;p class="p-3 mb-2 bg-body-secondary"&gt;.bg-body-secondary&lt;/p&gt;
-&lt;p class="p-3 mb-2 bg-body-tertiary"&gt;.bg-body-tertiary&lt;/p&gt;
+    <codeblock>&lt;section outputclass="p-3 mb-2 bg-primary text-white"&gt;.bg-primary&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-primary-subtle text-emphasis-primary"&gt;.bg-primary-subtle&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-secondary text-white"&gt;.bg-secondary&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-secondary-subtle text-emphasis-secondary"&gt;.bg-secondary-subtle&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-success text-white"&gt;.bg-success&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-success-subtle text-emphasis-success"&gt;.bg-success-subtle&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-danger text-white"&gt;.bg-danger&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-danger-subtle text-emphasis-danger"&gt;.bg-danger-subtle&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-warning text-dark"&gt;.bg-warning&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-warning-subtle text-emphasis-warning"&gt;.bg-warning-subtle&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-info text-dark"&gt;.bg-info&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-info-subtle text-emphasis-info"&gt;.bg-info-subtle&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-light text-dark"&gt;.bg-light&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-light-subtle text-emphasis-light"&gt;.bg-light-subtle&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-dark text-white"&gt;.bg-dark&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-dark-subtle text-emphasis-dark"&gt;.bg-dark-subtle&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-body-secondary"&gt;.bg-body-secondary&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-body-tertiary"&gt;.bg-body-tertiary&lt;/section&gt;
 
-&lt;section class="p-3 mb-2 bg-body text-body"&gt;.bg-body&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-black text-white"&gt;.bg-black&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-white text-dark"&gt;.bg-white&lt;/section&gt;
-&lt;section class="p-3 mb-2 bg-transparent text-body"&gt;.bg-transparent&lt;/section&gt;</codeblock>
+&lt;section outputclass="p-3 mb-2 bg-body text-body"&gt;.bg-body&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-black text-white"&gt;.bg-black&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-white text-dark"&gt;.bg-white&lt;/section&gt;
+&lt;section outputclass="p-3 mb-2 bg-transparent text-body"&gt;.bg-transparent&lt;/section&gt;</codeblock>
     <section>
       <title>Styling DITA elements</title>
       <p>Apply consistent Bootstrap utility classes across DITA elements by amending


### PR DESCRIPTION
This is a minimal change to get the links in the docs and XSLT to point at the latest release of Bootstrap 5.3