### PR TITLE
Update commit message & author for CI deployments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: out/html # The folder the action should deploy.
+          commit-message: '🚀 Deploy infotexture/dita-bootstrap@${GITHUB_SHA:0:7} to GitHub Pages'
+          git-config-name: 'GitHub Action'
+          git-config-email: 'action@github.com'


### PR DESCRIPTION
@jason-fox I'd like to update the commit message that's used when [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action) deploys the latest changes from the `develop` branch to GitHub Pages.

Based on the commits attributed to **GitHub Action** in your fork, I assume you've done something similar there.

Always hard to test CI without pushing spurious commits.

Does this look right?