### PR TITLE
Remove extension point

### DIFF
--- a/build_dita2html5-bootstrap_template.xml
+++ b/build_dita2html5-bootstrap_template.xml
@@ -4,7 +4,7 @@
 <project xmlns:if="ant:if" xmlns:dita="http://dita-ot.sourceforge.net">
   <target
     name="dita2html5-bootstrap"
-    dita:depends="{bootstrap.process.pre},dita2html5-bootstrap.init,
+    dita:depends="{bootstrap.process.pre},bootstrap.theme.init,dita2html5-bootstrap.init,
              dita2html5,{bootstrap.process.post}"
     dita:extension="depends org.dita.dost.platform.InsertDependsAction"
   />
@@ -206,8 +206,6 @@
   <target
     name="bootstrap.theme.init"
     if="bootstrap.theme"
-    dita:depends="{bootstrap.theme.pre}"
-    dita:extension="depends org.dita.dost.platform.InsertDependsAction"
   >
     <!-- Generate a custom theme based on a hdr template -->
     <tempfile

--- a/build_dita2html5-bootstrap_template.xml
+++ b/build_dita2html5-bootstrap_template.xml
@@ -203,10 +203,7 @@
     </condition>
   </target>
 
-  <target
-    name="bootstrap.theme.init"
-    if="bootstrap.theme"
-  >
+  <target name="bootstrap.theme.init" if="bootstrap.theme">
     <!-- Generate a custom theme based on a hdr template -->
     <tempfile
       property="bootstrap.theme.file"

--- a/plugin.xml
+++ b/plugin.xml
@@ -328,12 +328,6 @@
     id="bootstrap.process.post"
     name="Custom Bootstrap post-processing"
   />
-  <extension-point
-    id="bootstrap.theme.pre"
-    name="Custom Bootstrap theme pre-processing"
-  />
-
-  <feature extension="bootstrap.process.pre" value="bootstrap.theme.init"/>
   <!-- Add a template file to enable overrides to use extension points -->
   <template file="build_dita2html5-bootstrap_template.xml"/>
 </plugin>


### PR DESCRIPTION
Simplify by removing unnecessary extension point

```console
./dita -f html5-bootstrap \
	 -i ../plugins/dita-bootstrap/sample/document.ditamap

```console
./dita -f html5-bootstrap \
	 -i ../plugins/dita-bootstrap/sample/document.ditamap \
	 --bootstrap.theme=simplex```
```

```console
./dita -f html5-bootstrap \
	 -i ../plugins/dita-bootstrap/sample/document.ditamap '
	 --bootstrap.sass=yes   ```
```

```console
./dita -f html5-bootstrap \
	 -i ../plugins/dita-bootstrap/sample/document.ditamap \
	 --args.copycss=yes \
     --args.csspath=css \
     --args.cssroot=${PWD}/../plugins/dita-bootstrap/css \
     --args.css=custom.css
```