### PR TITLE
Describe offline mode

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 # This file specifies files that Prettier should not format
 
 backups
+build_dita2html5-bootstrap.xml
 cfg/common/vars/strings.xml
 css/custom.css
 out

--- a/sample/document.ditamap
+++ b/sample/document.ditamap
@@ -87,6 +87,11 @@
         <othermeta name="icon" content="bi-search"/>
       </topicmeta>
     </topicref>
+    <topicref navtitle="Offline Mode" format="dita" type="topic" href="offline.dita">
+      <topicmeta>
+        <othermeta name="icon" content="bi-wifi-off"/>
+      </topicmeta>
+    </topicref>
   </chapter>
   <backmatter deliveryTarget="pdf">
     <booklists>

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -147,7 +147,8 @@
           <parmname>--install</parmname> to install the plug-in.</li>
         <li>Build output with the <option>html5-bootstrap</option> type to verify that the output is available offline
           as intended.
-          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>path/to/your.ditamap</filepath> \
+          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
+            >path/to/your.ditamap</filepath> \
      <parmname>--format</parmname>=<option>html5-bootstrap</option> \
      <parmname>--offline.mode</parmname>=<option>yes</option></codeblock>
         </li>

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -71,7 +71,7 @@
 
           <fig>
             <title>Sample <filepath>offline-bootstrap-js.xml</filepath> file</title>
-            <codeblock outputclass="language-javascript">&lt;div&gt;
+            <codeblock outputclass="language-xml">&lt;div&gt;
   &lt;script&gt;
 //&lt;![CDATA[
   ... Place the entirety of bootstrap.bundle.min.js JavaScript here

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -107,7 +107,7 @@
             <title>Sample build file: <filepath>process_offline.xml</filepath></title>
             <codeblock outputclass="language-xml">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;
 &lt;project
-  name="dita.plugin.net.infotexture.dita-bootstrap.sass"
+  name="dita.plugin.com.example.bootstrap-offline"
   xmlns:if="ant:if"
   xmlns:unless="ant:unless"&gt;
   &lt;target name="bootstrap.offline" if="offline.mode"&gt;

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -128,7 +128,8 @@
     &lt;/condition&gt;
 
     &lt;offline-theme unless:set="offline.mode.no" /&gt;
-&lt;/target&gt;</codeblock>
+  &lt;/target&gt;
+&lt;/project&gt;</codeblock>
           </fig>
       </li>
     </ol>

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -11,8 +11,8 @@
    file for applicable licenses.-->
 <topic id="offline">
   <title>Offline Mode</title>
-  <shortdesc
-  >Offer content creators the opportunity to generate and view draft HTML in the Bootstrap style when not connected to the Internet through creating a custom DITA-OT plugin.</shortdesc>
+  <shortdesc>Offer content creators the opportunity to generate and view draft HTML in the Bootstrap style when not
+    connected to the Internet through creating a custom DITA-OT plugin.</shortdesc>
   <prolog>
     <metadata>
       <keywords>
@@ -22,26 +22,24 @@
   </prolog>
   <body outputclass="language-markup">
     <p>This scenario walks through the process of creating a simple plug-in
-      (<codeph>com.example.bootstrap.offline</codeph>) that bundles all the necessary
-      Bootstrap JavaScript and CSS <b>locally</b> into the generated HTML output.</p>
-    <p>This could be used to allow writers to view an incomplete draft of the DITA content
-      whilst maintaining Bootstrap interactivity and look-and-feel.</p>
-    <note>This offline approach deliberately avoids the use of online CDNs and minimises the
-      opportunity for browsers to cache files, and therefore is not recommended for
-      production of documents placed online.</note>
+        (<codeph>com.example.bootstrap.offline</codeph>) that bundles all the necessary Bootstrap JavaScript and CSS
+        <b>locally</b> into the generated HTML output.</p>
+    <p>This could be used to allow writers to view an incomplete draft of the DITA content whilst maintaining Bootstrap
+      interactivity and look-and-feel.</p>
+    <note>This offline approach deliberately avoids the use of online CDNs and minimises the opportunity for browsers to
+      cache files, and therefore is not recommended for production of documents placed online.</note>
 
     <section>
       <title>Procedure</title>
-    <ol>
-      <li>
-        <p>In the <filepath>plugins</filepath> directory, create a directory named
-        <filepath>com.example.bootstrap-offine</filepath>.</p>
-      </li>
-      <li>
-        <p>In the new <filepath>com.example.bootstrap-offline</filepath> directory, create a plug-in configuration file
-            (<filepath>plugin.xml</filepath>) that uses the
-            <option>bootstrap.process.pre</option> extension point.</p>
-
+      <ol>
+        <li>
+          <p>In the <filepath>plugins</filepath> directory, create a directory named
+              <filepath>com.example.bootstrap-offine</filepath>.</p>
+        </li>
+        <li>
+          <p>In the new <filepath>com.example.bootstrap-offline</filepath> directory, create a plug-in configuration
+            file (<filepath>plugin.xml</filepath>) that uses the <option>bootstrap.process.pre</option> extension
+            point.</p>
           <fig>
             <title>Sample <filepath>plugin.xml</filepath> file</title>
             <codeblock outputclass="language-xml">&lt;plugin id="com.example.bootstrap-offline" version="1.0.0"&gt;
@@ -57,18 +55,17 @@
   &lt;/transtype&gt;
 &lt;/plugin&gt;</codeblock>
           </fig>
-          <note>This plug-in will extend the default HTML5 Bootstrap transformation, so the <xmlelement
-            >require</xmlelement>
-            element explicitly defines <filepath>net.infotexture.dita-bootstrap</filepath> as a dependency.</note>
-      </li>
-      <li>
-        <p>In the <filepath>com.example.bootstrap-offline</filepath> directory, create a subdirectory named
-            <filepath>include</filepath>.</p>
-      </li>
-      <li>
-        <p>In the new <filepath>include</filepath> subdirectory, create a file named
-            <filepath>offline-bootstrap-js.xml</filepath> containing the minified Bootstrap JavaScript code.</p>
-
+          <note>This plug-in will extend the default HTML5 Bootstrap transformation, so the
+              <xmlelement>require</xmlelement> element explicitly defines
+              <filepath>net.infotexture.dita-bootstrap</filepath> as a dependency.</note>
+        </li>
+        <li>
+          <p>In the <filepath>com.example.bootstrap-offline</filepath> directory, create a subdirectory named
+              <filepath>include</filepath>.</p>
+        </li>
+        <li>
+          <p>In the new <filepath>include</filepath> subdirectory, create a file named
+              <filepath>offline-bootstrap-js.xml</filepath> containing the minified Bootstrap JavaScript code.</p>
           <fig>
             <title>Sample <filepath>offline-bootstrap-js.xml</filepath> file</title>
             <codeblock outputclass="language-xml">&lt;div&gt;
@@ -81,11 +78,10 @@
           </fig>
           <p>The division wrapper will be discarded when generating HTML files, and the contents will be inserted into
             the <xmlelement>header</xmlelement> element of each page.</p>
-      </li>
-      <li>
-        <p>In the new <filepath>include</filepath> subdirectory, create a file named
-            <filepath>offline-bootstrap.css</filepath> containing the minified Bootstrap CSS.</p>
-
+        </li>
+        <li>
+          <p>In the new <filepath>include</filepath> subdirectory, create a file named
+              <filepath>offline-bootstrap.css</filepath> containing the minified Bootstrap CSS.</p>
           <fig>
             <title>Sample <filepath>offline-bootstrap.css</filepath> file</title>
             <codeblock outputclass="language-css">@charset "UTF-8";
@@ -96,13 +92,12 @@
  */
 ... Place entirety of the bootstrap.min.css stylesheet here</codeblock>
           </fig>
-      </li>
+        </li>
 
-      <li>
-        <p>In the <filepath>com.example.bootstrap-offline</filepath> root directory, add an Ant script
-            (<filepath>process_offline.xml</filepath>) to predefine various parameters prior to calling the <option
-            >html5-bootstrap</option> transform</p>
-
+        <li>
+          <p>In the <filepath>com.example.bootstrap-offline</filepath> root directory, add an Ant script
+              (<filepath>process_offline.xml</filepath>) to predefine various parameters prior to calling the
+              <option>html5-bootstrap</option> transform</p>
           <fig>
             <title>Sample build file: <filepath>process_offline.xml</filepath></title>
             <codeblock outputclass="language-xml">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;
@@ -131,8 +126,8 @@
   &lt;/target&gt;
 &lt;/project&gt;</codeblock>
           </fig>
-      </li>
-    </ol>
+        </li>
+      </ol>
     </section>
     <section>
       <title>Results</title>
@@ -148,11 +143,11 @@
     <section>
       <title>What to do next</title>
       <ol>
-        <li>Run <cmdname>dita</cmdname> <parmname>--install</parmname> to install the plug-in.</li>
-        <li>Build output with the <option
-          >html5-bootstrap</option> type to verify that the output is available offline as intended.
-           <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
-            >path/to/your.ditamap</filepath> \
+        <li>Run <cmdname>dita</cmdname>
+          <parmname>--install</parmname> to install the plug-in.</li>
+        <li>Build output with the <option>html5-bootstrap</option> type to verify that the output is available offline
+          as intended.
+          <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>path/to/your.ditamap</filepath> \
      <parmname>--format</parmname>=<option>html5-bootstrap</option>
      <parmname>--offline.mode</parmname>=<option>yes</option></codeblock>
         </li>

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<!-- Within the sample documentation, where necessary, the texts describing the
+   usage of each component have been copied directly from the official Bootstrap
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
+   markup is used throughout the examples describing how to implement these
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
+<topic id="offline">
+  <title>Offline Mode</title>
+  <shortdesc
+  >Offer content creators the opportunity to generate and view draft HTML in the Bootstrap style when not connected to the Internet through creating a custom DITA-OT plugin.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>Offline</indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <body outputclass="language-markup">
+    <p>This scenario walks through the process of creating a simple plug-in
+      (<codeph>com.example.bootstrap.offline</codeph>) that bundles all the necessary
+      Bootstrap JavaScript and CSS <b>locally</b> into the generated HTML output.</p>
+    <p>This could be used to allow writers to view an incomplete draft of the DITA content
+      whilst maintaining Bootstrap interactivity and look-and-feel.</p>
+    <note>This offline approach deliberately avoids the use of online CDNs and minimises the
+      opportunity for browsers to cache files, and therefore is not recommended for
+      production of documents placed online.</note>
+
+    <section>
+      <title>Procedure</title>
+    <ol>
+      <li>
+        <p>In the <filepath>plugins</filepath> directory, create a directory named
+        <filepath>com.example.bootstrap-offine</filepath>.</p>
+      </li>
+      <li>
+        <p>In the new <filepath>com.example.bootstrap-offline</filepath> directory, create a plug-in configuration file
+            (<filepath>plugin.xml</filepath>) that uses the
+            <option>bootstrap.process.pre</option> extension point.</p>
+
+          <fig>
+            <title>Sample <filepath>plugin.xml</filepath> file</title>
+            <codeblock outputclass="language-xml">&lt;plugin id="com.example.bootstrap-offline" version="1.0.0"&gt;
+  &lt;require plugin="net.infotexture.dita-bootstrap" /&gt;
+  &lt;feature extension="ant.import" file="process_offline.xml" /&gt;
+  &lt;feature extension="bootstrap.process.pre" value="offline-bootstrap" /&gt;
+&lt;/plugin&gt;</codeblock>
+          </fig>
+          <note>This plug-in will extend the default HTML5 Bootstrap transformation, so the <xmlelement
+            >require</xmlelement>
+            element explicitly defines <filepath>net.infotexture.dita-bootstrap</filepath> as a dependency.</note>
+      </li>
+      <li>
+        <p>In the <filepath>com.example.bootstrap-offline</filepath> directory, create a subdirectory named
+            <filepath>include</filepath>.</p>
+      </li>
+      <li>
+        <p>In the new <filepath>include</filepath> subdirectory, create a file named
+            <filepath>offline-bootstrap-js.xml</filepath> containing the minified Bootstrap JavaScript code.</p>
+
+          <fig>
+            <title>Sample <filepath>offline-bootstrap-js.xml</filepath> file</title>
+            <codeblock outputclass="language-javascript">&lt;div&gt;
+  &lt;script&gt;
+//&lt;![CDATA[
+  ... Place the entirety of bootstrap.bundle.min.js JavaScript here
+//]&#8203;]&gt;
+  &lt;/script&gt;
+&lt;/div&gt;</codeblock>
+          </fig>
+          <p>The division wrapper will be discarded when generating HTML files, and the contents will be inserted into
+            the <xmlelement>header</xmlelement> element of each page.</p>
+      </li>
+      <li>
+        <p>In the new <filepath>include</filepath> subdirectory, create a file named
+            <filepath>offline-bootstrap.css</filepath> containing the minified Bootstrap CSS.</p>
+
+          <fig>
+            <title>Sample <filepath>offline-bootstrap.css</filepath> file</title>
+            <codeblock outputclass="language-css">@charset "UTF-8";
+/*!
+ * Bootstrap  v5.3.0 (https://getbootstrap.com/)
+ * Copyright 2011-2023 The Bootstrap Authors
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
+ */
+... Place entirety of the bootstrap.min.css stylesheet here</codeblock>
+          </fig>
+      </li>
+
+      <li>
+        <p>In the <filepath>com.example.bootstrap-offline</filepath> root directory, add an Ant script
+            (<filepath>process_offline.xml</filepath>) to predefine various parameters prior to calling the <option
+            >html5-bootstrap</option> transform</p>
+
+          <fig>
+            <title>Sample build file: <filepath>process_offline.xml</filepath></title>
+            <codeblock outputclass="language-xml">
+&lt;?xml version="1.0" encoding="UTF-8" ?&gt;
+&lt;project name="com.example.bootstrap-offline"&gt;
+&lt;target name="offline-bootstrap"&gt;
+  &lt;property name="args.copycss" value="yes" /&gt;
+  &lt;property name="args.csspath" value="css" /&gt;
+  &lt;property name="args.css" value="offline-bootstrap.css" /&gt;
+  &lt;property name="args.cssroot"
+    value="${dita.plugin.com.example.bootstrap-offline}/include" /&gt;
+  &lt;property name="args.hdf"
+    value="${dita.plugin.com.example.bootstrap-offline}/include/offline-bootstrap-js.xml" /&gt;
+&lt;/target&gt;</codeblock>
+          </fig>
+      </li>
+    </ol>
+    </section>
+    <section>
+      <title>Results</title>
+      <p>The plug-in directory has the following layout and files:</p>
+      <codeblock outputclass="language-bash">com.example.bootstrap-offline
+├── include
+│   ├── offline-bootstrap-js.xml
+│   └── offline-bootstrap.css
+├── process_offline.xml
+└── plugin.xml</codeblock>
+    </section>
+
+    <section>
+      <title>What to do next</title>
+      <ol>
+        <li>Run <cmdname>dita</cmdname> <parmname>--install</parmname> to install the plug-in.</li>
+        <li>Build output with the <option
+          >html5-bootstrap</option> type to verify that the output is available offline as intended.
+           <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
+            >path/to/your.ditamap</filepath> \
+     <parmname>--format</parmname>=<option>html5-bootstrap</option></codeblock>
+        </li>
+        <li>Refine the styles in your <filepath>offline-bootstrap.css</filepath> file as necessary.</li>
+      </ol>
+    </section>
+  </body>
+</topic>

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -45,7 +45,7 @@
             <codeblock outputclass="language-xml">&lt;plugin id="com.example.bootstrap-offline" version="1.0.0"&gt;
   &lt;require plugin="net.infotexture.dita-bootstrap" /&gt;
   &lt;feature extension="ant.import" file="process_offline.xml" /&gt;
-  &lt;feature extension="bootstrap.process.pre" value="offline-bootstrap" /&gt;
+  &lt;feature extension="bootstrap.process.pre" value="bootstrap.offline" /&gt;
 
   &lt;transtype name="html5-bootstrap" extends="html5"&gt;
     &lt;param name="offline.mode" type="enum"&gt;

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -105,8 +105,7 @@
 
           <fig>
             <title>Sample build file: <filepath>process_offline.xml</filepath></title>
-            <codeblock outputclass="language-xml">
-&lt;?xml version="1.0" encoding="UTF-8" ?&gt;
+            <codeblock outputclass="language-xml">&lt;?xml version="1.0" encoding="UTF-8" ?&gt;
 &lt;project
   name="dita.plugin.net.infotexture.dita-bootstrap.sass"
   xmlns:if="ant:if"

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -141,8 +141,8 @@
 ├── include
 │   ├── offline-bootstrap-js.xml
 │   └── offline-bootstrap.css
-├── process_offline.xml
-└── plugin.xml</codeblock>
+├── plugin.xml
+└── process_offline.xml</codeblock>
     </section>
 
     <section>

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -110,7 +110,7 @@
   name="dita.plugin.net.infotexture.dita-bootstrap.sass"
   xmlns:if="ant:if"
   xmlns:unless="ant:unless"&gt;
-  &lt;target name="bootstrap.sass" if="offline.mode"&gt;
+  &lt;target name="bootstrap.offline" if="offline.mode"&gt;
     &lt;macrodef name="offline-theme"&gt;
       &lt;sequential&gt;
         &lt;property name="args.copycss" value="yes" /&gt;

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -112,9 +112,9 @@
         &lt;property name="args.csspath" value="css" /&gt;
         &lt;property name="args.css" value="offline-bootstrap.css" /&gt;
         &lt;property name="args.cssroot"
-          value="${dita.plugin.com.example.bootstrap-offline}/include" /&gt;
+          value="${dita.plugin.com.example.bootstrap-offline.dir}/include" /&gt;
         &lt;property name="args.hdf"
-          value="${dita.plugin.com.example.bootstrap-offline}/include/offline-bootstrap-js.xml" /&gt;
+          value="${dita.plugin.com.example.bootstrap-offline.dir}/include/offline-bootstrap-js.xml" /&gt;
       &lt;/sequential&gt;
     &lt;/macrodef&gt;
 

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -48,6 +48,13 @@
   &lt;require plugin="net.infotexture.dita-bootstrap" /&gt;
   &lt;feature extension="ant.import" file="process_offline.xml" /&gt;
   &lt;feature extension="bootstrap.process.pre" value="offline-bootstrap" /&gt;
+
+  &lt;transtype name="html5-bootstrap" extends="html5"&gt;
+    &lt;param name="offline.mode" type="enum"&gt;
+      &lt;val&gt;yes&lt;/val&gt;
+      &lt;val default="true"&gt;no&lt;/val&gt;
+    &lt;/param&gt;
+  &lt;/transtype&gt;
 &lt;/plugin&gt;</codeblock>
           </fig>
           <note>This plug-in will extend the default HTML5 Bootstrap transformation, so the <xmlelement
@@ -100,15 +107,28 @@
             <title>Sample build file: <filepath>process_offline.xml</filepath></title>
             <codeblock outputclass="language-xml">
 &lt;?xml version="1.0" encoding="UTF-8" ?&gt;
-&lt;project name="com.example.bootstrap-offline"&gt;
-&lt;target name="offline-bootstrap"&gt;
-  &lt;property name="args.copycss" value="yes" /&gt;
-  &lt;property name="args.csspath" value="css" /&gt;
-  &lt;property name="args.css" value="offline-bootstrap.css" /&gt;
-  &lt;property name="args.cssroot"
-    value="${dita.plugin.com.example.bootstrap-offline}/include" /&gt;
-  &lt;property name="args.hdf"
-    value="${dita.plugin.com.example.bootstrap-offline}/include/offline-bootstrap-js.xml" /&gt;
+&lt;project
+  name="dita.plugin.net.infotexture.dita-bootstrap.sass"
+  xmlns:if="ant:if"
+  xmlns:unless="ant:unless"&gt;
+  &lt;target name="bootstrap.sass" if="offline.mode"&gt;
+    &lt;macrodef name="offline-theme"&gt;
+      &lt;sequential&gt;
+        &lt;property name="args.copycss" value="yes" /&gt;
+        &lt;property name="args.csspath" value="css" /&gt;
+        &lt;property name="args.css" value="offline-bootstrap.css" /&gt;
+        &lt;property name="args.cssroot"
+          value="${dita.plugin.com.example.bootstrap-offline}/include" /&gt;
+        &lt;property name="args.hdf"
+          value="${dita.plugin.com.example.bootstrap-offline}/include/offline-bootstrap-js.xml" /&gt;
+      &lt;/sequential&gt;
+    &lt;/macrodef&gt;
+
+    &lt;condition property="offline.mode.no"&gt;
+      &lt;equals arg1="${offline.mode}" arg2="no" /&gt;
+    &lt;/condition&gt;
+
+    &lt;offline-theme unless:set="offline.mode.no" /&gt;
 &lt;/target&gt;</codeblock>
           </fig>
       </li>
@@ -133,7 +153,8 @@
           >html5-bootstrap</option> type to verify that the output is available offline as intended.
            <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
             >path/to/your.ditamap</filepath> \
-     <parmname>--format</parmname>=<option>html5-bootstrap</option></codeblock>
+     <parmname>--format</parmname>=<option>html5-bootstrap</option>
+     <parmname>--offline.mode</parmname>=<option>yes</option></codeblock>
         </li>
         <li>Refine the styles in your <filepath>offline-bootstrap.css</filepath> file as necessary.</li>
       </ol>

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -148,7 +148,7 @@
         <li>Build output with the <option>html5-bootstrap</option> type to verify that the output is available offline
           as intended.
           <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath>path/to/your.ditamap</filepath> \
-     <parmname>--format</parmname>=<option>html5-bootstrap</option>
+     <parmname>--format</parmname>=<option>html5-bootstrap</option> \
      <parmname>--offline.mode</parmname>=<option>yes</option></codeblock>
         </li>
         <li>Refine the styles in your <filepath>offline-bootstrap.css</filepath> file as necessary.</li>


### PR DESCRIPTION
Update the documentation to describe how to create an additional custom plugin which offers **offline mode** - this procedure is not recommended for a production environment since it avoids caching of files from the Internet and would be slower than normal online.

Custom plugin because adding it directly would also bloat the plugin codebase with unnecessary duplicates of the Bootstrap files.