### PR TITLE
Tweak Scroll Margin values

### DIFF
--- a/css/menubar-toc.css
+++ b/css/menubar-toc.css
@@ -17,7 +17,8 @@
   }
 }
 
-.nested0 {
+.nested0,
+article h1 {
   scroll-margin-top: 11.25rem;
 }
 

--- a/css/menubar-toc.css
+++ b/css/menubar-toc.css
@@ -17,7 +17,11 @@
   }
 }
 
-article h1,
+.nested0 {
+  scroll-margin-top: 11.25rem;
+}
+
+.nested1,
 article h2,
 article h3,
 article h4,

--- a/css/none-toc.css
+++ b/css/none-toc.css
@@ -12,3 +12,8 @@
   grid-template-areas: 'main';
   grid-template-columns: 1fr;
 }
+
+.nested0,
+article h1 {
+  scroll-margin-top: 7.25rem;
+}

--- a/css/scrollspy-toc.css
+++ b/css/scrollspy-toc.css
@@ -83,16 +83,10 @@
   font: inherit;
 }
 
-.nested0 {
-  scroll-margin-top: 5rem;
-}
-
 .nested1,
-article h1,
 article h2,
 article h3,
 article h4,
 article [tabindex='0'] {
-  scroll-margin-top: 5.25rem;
   scroll-margin-bottom: 100px;
 }

--- a/css/side-toc.css
+++ b/css/side-toc.css
@@ -90,3 +90,11 @@
     border-right-color: var(--bs-border-color);
   }
 }
+
+.nested0 {
+  scroll-margin-top: 7.25rem;
+}
+
+.nested1 {
+  scroll-margin-top: 5.25rem;
+}

--- a/css/side-toc.css
+++ b/css/side-toc.css
@@ -91,10 +91,15 @@
   }
 }
 
-.nested0 {
+.nested0,
+article h1 {
   scroll-margin-top: 7.25rem;
 }
 
-.nested1 {
+.nested1,
+article h2,
+article h3,
+article h4,
+article [tabindex='0'] {
   scroll-margin-top: 5.25rem;
 }


### PR DESCRIPTION
Discovered whilst testing #102

Minor rejig of scroll margin values to support more use cases. It used to be the case that `scroll-margin` was only added if a scroll spy was present since that was when **jump to topic** was used, however this is not the only case. It is also possible to have a **jump to topic** when using   the `chunk="to-content"` attribute on a topic. This makes the **jump to topic**  present on the sidebar.

So the `scroll-margin` needs to shift to `sidebar-toc` from `scrollspy-toc`, and an additional override needs to be present if there is a menu bar as well.