### PR TITLE
Potential fix #101 = use make URL to avoid windows slash issue.

### DIFF
--- a/build_dita2html5-bootstrap_template.xml
+++ b/build_dita2html5-bootstrap_template.xml
@@ -155,9 +155,9 @@
       location="${dita.plugin.net.infotexture.dita-bootstrap.dir}/includes/bs-navbar-default.hdr.xml"
     />
     <!-- Location of bootstrap icons if required -->
-    <property
-      name="icons.cdn.path"
-      location="${dita.plugin.net.infotexture.dita-bootstrap.dir}/includes/bootstrap.icons.hdf.xml"
+    <makeurl
+      property="icons.cdn.path"
+      file="${dita.plugin.net.infotexture.dita-bootstrap.dir}/includes/bootstrap.icons.hdf.xml"
     />
     <!-- Entrypoint for XSL transforms -->
     <property


### PR DESCRIPTION
Using `<makeurl>` does no harm, and could fix an Windows issue.