### PR TITLE
Add Bootstrap classes to Footer

### DIFF
--- a/.github/dita-ot/footer.xml
+++ b/.github/dita-ot/footer.xml
@@ -4,10 +4,6 @@
     <div class="col">
       <!-- Social media -->
       <p class="p-3">
-        <!-- Twitter -->
-        <a class="btn btn-primary m-1" href="" role="button"><i
-            class="bi bi-twitter"
-          /></a>
         <!-- GitHub -->
         <a
           class="btn m-1"

--- a/.github/dita-ot/footer.xml
+++ b/.github/dita-ot/footer.xml
@@ -3,25 +3,22 @@
   <div class="row">
     <div class="col">
       <!-- Social media -->
-      <p class="text-center p-3">
+      <p class="p-3">
         <!-- GitHub -->
         <a
-          class="btn btn-primary btn-floating m-1"
-          style="background-color: #333333"
+          class="btn btn-primary m-1"
           href="https://github.com/infotexture/dita-bootstrap"
           role="button"
         ><i class="bi bi-github"/></a>
         <!-- Linkedin -->
         <a
-          class="btn btn-primary btn-floating m-1"
-          style="background-color: #0082ca"
+          class="btn btn-primary m-1"
           href="https://www.linkedin.com/in/infotexture/"
           role="button"
         ><i class="bi bi-linkedin"/></a>
         <!-- Twitter -->
         <a
-          class="btn btn-primary btn-floating m-1"
-          style="background-color: #55acee"
+          class="btn btn-primary m-1"
           href="https://twitter.com/infotexture"
           role="button"
         ><i class="bi bi-twitter"/></a>

--- a/.github/dita-ot/footer.xml
+++ b/.github/dita-ot/footer.xml
@@ -35,7 +35,7 @@
       <p class="p-3">
         <small>
           © 2017–2023
-          <a class="text-dark" href="https://infotexture.net/">infotexture</a>
+          <a href="https://infotexture.net/">infotexture</a>
         </small>
       </p>
     </div>

--- a/.github/dita-ot/footer.xml
+++ b/.github/dita-ot/footer.xml
@@ -3,7 +3,7 @@
   <div class="row">
     <div class="col">
       <!-- Social media -->
-      <p class="p-3">
+      <p class="pt-3">
         <!-- GitHub -->
         <a
           class="btn m-1"
@@ -32,7 +32,7 @@
           <i class="bi bi-twitter text-white"/>
         </a>
       </p>
-      <p class="p-3">
+      <p>
         <small>
           © 2017–2023
           <a href="https://infotexture.net/">infotexture</a>

--- a/.github/dita-ot/footer.xml
+++ b/.github/dita-ot/footer.xml
@@ -4,24 +4,37 @@
     <div class="col">
       <!-- Social media -->
       <p class="p-3">
+        <!-- Twitter -->
+        <a class="btn btn-primary m-1" href="" role="button"><i
+            class="bi bi-twitter"
+          /></a>
         <!-- GitHub -->
         <a
-          class="btn btn-primary m-1"
+          class="btn m-1"
           href="https://github.com/infotexture/dita-bootstrap"
           role="button"
-        ><i class="bi bi-github"/></a>
+          style="background-color: #333333;"
+        >
+          <i class="bi bi-github text-white"/>
+        </a>
         <!-- Linkedin -->
         <a
-          class="btn btn-primary m-1"
+          class="btn m-1"
           href="https://www.linkedin.com/in/infotexture/"
           role="button"
-        ><i class="bi bi-linkedin"/></a>
+          style="background-color: #0082ca;"
+        >
+          <i class="bi bi-linkedin text-white"/>
+        </a>
         <!-- Twitter -->
         <a
-          class="btn btn-primary m-1"
+          class="btn m-1"
           href="https://twitter.com/infotexture"
           role="button"
-        ><i class="bi bi-twitter"/></a>
+          style="background-color: #55acee;"
+        >
+          <i class="bi bi-twitter text-white"/>
+        </a>
       </p>
       <p class="p-3">
         <small>

--- a/.github/dita-ot/footer.xml
+++ b/.github/dita-ot/footer.xml
@@ -22,14 +22,14 @@
         >
           <i class="bi bi-linkedin text-white"/>
         </a>
-        <!-- Twitter -->
+        <!-- Mastodon -->
         <a
           class="btn m-1"
-          href="https://twitter.com/infotexture"
+          href="https://indieweb.social/@infotexture"
           role="button"
-          style="background-color: #55acee;"
+          style="background-color: #563acc;"
         >
-          <i class="bi bi-twitter text-white"/>
+          <i class="bi bi-mastodon text-white"/>
         </a>
       </p>
       <p>

--- a/.github/dita-ot/theme.css
+++ b/.github/dita-ot/theme.css
@@ -7,7 +7,6 @@
 
 /* ↓  Additional custom overrides  ↓ */
 
-
 /* Add Bootstrap’s own documentation example highlight */
 
 .bd-example {

--- a/.github/dita-ot/theme.css
+++ b/.github/dita-ot/theme.css
@@ -7,11 +7,6 @@
 
 /* ↓  Additional custom overrides  ↓ */
 
-footer {
-  background-color: #e7f1ff;
-  border-top: 1px solid rgba(0, 0, 0, 0.125);
-  margin-top: 3rem;
-}
 
 /* Add Bootstrap’s own documentation example highlight */
 

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -14,6 +14,7 @@
 
   <xsl:param name="defaultLanguage" select="'en'" as="xs:string"/>
   <xsl:param name="BIDIRECTIONAL_DOCUMENT" select="'no'" as="xs:string"/>
+  <xsl:param name="BOOTSTRAP_CSS_FOOTER" select="'mt-3 border-top bg-primary-subtle'"/>
 
   <xsl:variable name="defaultDirection">
     <xsl:apply-templates select="." mode="get-render-direction">
@@ -409,5 +410,22 @@
       <xsl:call-template name="setidaname"/>
       <xsl:apply-templates/>
     </abbr>
+  </xsl:template>
+
+  <xsl:template match="*" mode="addFooterToHtmlBodyElement">
+    <xsl:variable name="footer-content" as="node()*">
+      <xsl:call-template name="gen-user-footer"/> <!-- include user's XSL running footer here -->
+      <xsl:call-template name="processFTR"/>      <!-- Include XHTML footer, if specified -->
+    </xsl:variable>
+    <xsl:if test="exists($footer-content)">
+      <footer xsl:use-attribute-sets="footer">
+        <!-- ↓ Add Bootstrap CSS ↓ -->
+        <xsl:attribute name="class">
+          <xsl:value-of select="$BOOTSTRAP_CSS_FOOTER"/>
+        </xsl:attribute>
+        <xsl:sequence select="$footer-content"/>
+         <!-- ↓ Add Bootstrap CSS ↓ -->
+      </footer>
+    </xsl:if>
   </xsl:template>
 </xsl:stylesheet>

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -435,6 +435,9 @@
         <!-- ↓ Add Bootstrap CSS ↓ -->
         <xsl:attribute name="class">
           <xsl:value-of select="$BOOTSTRAP_CSS_FOOTER"/>
+          <xsl:if test="not($TOC_SPACER_PADDING = '0')">
+            <xsl:value-of select="concat(' py-', $TOC_SPACER_PADDING)"/>
+          </xsl:if>
         </xsl:attribute>
         <xsl:sequence select="$footer-content"/>
          <!-- ↓ Add Bootstrap CSS ↓ -->

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -78,8 +78,11 @@
         </xsl:if>
         <!-- ↑ End customization · Continue with DITA-OT defaults ↓ -->
         <xsl:attribute name="aria-labelledby">
-          <xsl:apply-templates select="*[contains(@class,' topic/title ')] |
-                                       self::dita/*[1]/*[contains(@class,' topic/title ')]" mode="return-aria-label-id"/>
+          <xsl:apply-templates
+            select="*[contains(@class,' topic/title ')] |
+                                       self::dita/*[1]/*[contains(@class,' topic/title ')]"
+            mode="return-aria-label-id"
+          />
         </xsl:attribute>
         <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]" mode="out-of-line"/>
         <!-- ↓ Add Bootstrap breadcrumb ↓ -->
@@ -152,19 +155,23 @@
             </xsl:analyze-string>
           </xsl:for-each>
         </xsl:variable>
-        <xsl:for-each select="@props |
+        <xsl:for-each
+          select="@props |
                               @audience |
                               @platform |
                               @product |
                               @otherprops |
                               @deliveryTarget |
-                              @*[local-name() = $specializations]">
+                              @*[local-name() = $specializations]"
+        >
           <xsl:attribute name="data-{name()}" select="."/>
         </xsl:for-each>
       </xsl:when>
       <xsl:when test="exists($passthrough-attrs)">
         <xsl:for-each select="@*">
-          <xsl:if test="$passthrough-attrs[@att = name(current()) and (empty(@val) or (some $v in tokenize(current(), '\s+') satisfies $v = @val))]">
+          <xsl:if
+            test="$passthrough-attrs[@att = name(current()) and (empty(@val) or (some $v in tokenize(current(), '\s+') satisfies $v = @val))]"
+          >
             <xsl:attribute name="data-{name()}" select="."/>
           </xsl:if>
         </xsl:for-each>
@@ -208,7 +215,10 @@
         </xsl:call-template>
       </span>
       <xsl:text> </xsl:text>
-      <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/revprop" mode="ditaval-outputflag"/>
+      <xsl:apply-templates
+        select="*[contains(@class, ' ditaot-d/ditaval-startprop ')]/revprop"
+        mode="ditaval-outputflag"
+      />
       <xsl:apply-templates/>
       <!-- Normal end flags and revision end flags both go out after the content. -->
       <xsl:apply-templates select="*[contains(@class, ' ditaot-d/ditaval-endprop ')]" mode="out-of-line"/>
@@ -250,7 +260,10 @@
   <xsl:template name="place-fig-lbl">
     <xsl:param name="stringName"/>
     <!-- Number of fig/title's including this one -->
-    <xsl:variable name="fig-count-actual" select="count(preceding::*[contains(@class, ' topic/fig ')]/*[contains(@class, ' topic/title ')])+1"/>
+    <xsl:variable
+      name="fig-count-actual"
+      select="count(preceding::*[contains(@class, ' topic/fig ')]/*[contains(@class, ' topic/title ')])+1"
+    />
     <xsl:variable name="ancestorlang">
       <xsl:call-template name="getLowerCaseLang"/>
     </xsl:variable>

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For more extensive Sass customizations, you may want to install the [dita-bootst
 
 The plug-in includes a default static navigation menu with a project name and global link placeholders.
 
-The default header file `includes/bs-navbar-default.hdr.xml` uses the Bootstrap primary (blue) background color for the [navbar component][3]. Bootstrap itself offers additional [header examples][20]
+The default header file `includes/bs-navbar-default.hdr.xml` uses the Bootstrap primary (blue) background color for the [navbar component][3]. Bootstrap itself offers additional [header examples][20].
 
 To change the color to a dark (black) background, replace the primary background color class `bg-primary` on the first line with the dark variant `bg-dark`:
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For more extensive Sass customizations, you may want to install the [dita-bootst
 
 The plug-in includes a default static navigation menu with a project name and global link placeholders.
 
-The default header file `includes/bs-navbar-default.hdr.xml` uses the Bootstrap primary (blue) background color for the [navbar component][3].
+The default header file `includes/bs-navbar-default.hdr.xml` uses the Bootstrap primary (blue) background color for the [navbar component][3]. Bootstrap itself offers additional [header examples][20]
 
 To change the color to a dark (black) background, replace the primary background color class `bg-primary` on the first line with the dark variant `bg-dark`:
 
@@ -113,7 +113,7 @@ dita --input=path/to/your.ditamap \
 
 The plug-in includes a sample [header alternative with a light navbar][4].
 
-No footer is added by default, but the plug-in also includes a sample [footer file][5]. To add a footer to the generated output, pass a custom footer file to the `dita` command via the `--args.ftr` parameter:
+No footer is added by default, but the plug-in also includes a sample [footer file][5] and Bootstrap also offers additional [examples][19]. To add a footer to the generated output, pass a custom footer file to the `dita` command via the `--args.ftr` parameter:
 
 ```console
 dita --input=path/to/your.ditamap \
@@ -253,3 +253,5 @@ Within the sample documentation, where necessary, the texts describing the usage
 [16]: https://getbootstrap.com/docs/5.3/components/collapse/
 [17]: https://getbootstrap.com/docs/5.3/customize/color-modes/#dark-mode
 [18]: https://getbootstrap.com/docs/5.3/components/scrollspy/
+[19]: https://getbootstrap.com/docs/5.3/examples/footers/
+[20]: https://getbootstrap.com/docs/5.3/examples/headers/

--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ The HTML output for the following DITA elements can be annotated with common Boo
 - `bootstrap.css.figure` – common utility classes for DITA `<fig>` elements
 - `bootstrap.css.figure.caption` – common utility classes for DITA figure titles
 - `bootstrap.css.figure.image` – common utility classes for images within DITA`<fig>` elements
+- `bootstrap.css.footer` – common utility classes for the HTML `<footer>` element
 - `bootstrap.css.nav.parent` – common utility classes for ancestors of active nav-pill elements
 - `bootstrap.css.pagination` – common utility classes for Bootstrap pagination components
 - `bootstrap.css.section.title` – common Bootstrap utility classes for DITA `<section>` titles
@@ -211,7 +212,7 @@ Bootstrap icons, popovers, tooltips and the dark-mode toggler are enabled by def
 - `popovers.include` – enable Bootstrap popover components and tooltip components
 - `dark.mode.include` - whether to include support for a [dark mode][17] toggler
 
-Additionally, opt-in breadcrumbs and menu bars can be added using the following parameters
+Additionally, opt-in breadcrumbs and menu bars and other modifiers can be added using the following parameters
 
 - `args.breadcrumbs` – add Bootstrap breadcrumb components
 - `menubar-toc.include` – add a Bootstrap menubar

--- a/includes/bs-footer-example.xml
+++ b/includes/bs-footer-example.xml
@@ -5,27 +5,15 @@
       <!-- Social media -->
       <p class="text-center p-3">
         <!-- GitHub -->
-        <a
-          class="btn btn-primary m-1"
-          href="#!"
-          role="button"
-        >
+        <a class="btn btn-primary m-1" href="#!" role="button">
           <i class="bi bi-github"/>
         </a>
         <!-- Linkedin -->
-        <a
-          class="btn btn-primary m-1"
-          href="#!"
-          role="button"
-        >
+        <a class="btn btn-primary m-1" href="#!" role="button">
           <i class="bi bi-linkedin"/>
         </a>
         <!-- Twitter -->
-        <a
-          class="btn btn-primary m-1"
-          href="#!"
-          role="button"
-        >
+        <a class="btn btn-primary m-1" href="#!" role="button">
           <i class="bi bi-twitter"/>
         </a>
       </p>

--- a/includes/bs-footer-example.xml
+++ b/includes/bs-footer-example.xml
@@ -1,138 +1,137 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Footer -->
 <div class="container text-center">
-   <div class="row">
-      <div class="col">
-         <!-- Social media -->
-         <p class="text-center p-3">
-            <!-- GitHub -->
-            <a
+  <div class="row">
+    <div class="col">
+      <!-- Social media -->
+      <p class="pt-3">
+        <!-- GitHub -->
+        <a
           class="btn m-1"
           href="#!"
           role="button"
           style="background-color: #333333;"
         >
-               <i class="bi bi-github text-white"/>
-            </a>
-            <!-- Linkedin -->
-            <a
+          <i class="bi bi-github text-white"/>
+        </a>
+        <!-- Linkedin -->
+        <a
           class="btn m-1"
           href="#!"
           role="button"
           style="background-color: #0082ca;"
         >
-               <i class="bi bi-linkedin text-white"/>
-            </a>
-            <!-- Twitter -->
-            <a
+          <i class="bi bi-linkedin text-white"/>
+        </a>
+        <!-- Twitter -->
+        <a
           class="btn m-1"
           href="#!"
           role="button"
           style="background-color: #55acee;"
         >
-               <i class="bi bi-twitter text-white"/>
-            </a>
-            <!-- Facebook -->
-            <a
+          <i class="bi bi-twitter text-white"/>
+        </a>
+        <!-- Facebook -->
+        <a
           class="btn m-1"
           style="background-color: #3b5998;"
           href="#!"
           role="button"
         >
-               <i class="bi bi-facebook text-white"/>
-            </a>
-            <!-- Google -->
-            <a
+          <i class="bi bi-facebook text-white"/>
+        </a>
+        <!-- Google -->
+        <a
           class="btn m-1"
           style="background-color: #dd4b39;"
           href="#!"
           role="button"
         >
-               <i class="bi bi-google text-white"/>
-            </a>
-            <!-- Instagram -->
-            <a
+          <i class="bi bi-google text-white"/>
+        </a>
+        <!-- Instagram -->
+        <a
           class="btn m-1"
           style="background-color: #ac2bac;"
           href="#!"
           role="button"
         >
-               <i class="bi bi-instagram text-white"/>
-            </a>
-            <!-- Pinterest -->
-            <a
+          <i class="bi bi-instagram text-white"/>
+        </a>
+        <!-- Pinterest -->
+        <a
           class="btn m-1"
           style="background-color: #c61118;"
           href="#!"
           role="button"
         >
-               <i class="bi bi-pinterest text-white"/>
-            </a>
-            <!-- Stack overflow -->
-            <a
+          <i class="bi bi-pinterest text-white"/>
+        </a>
+        <!-- Stack overflow -->
+        <a
           class="btn m-1"
           style="background-color: #ffac44;"
           href="#!"
           role="button"
         >
-               <i class="bi bi-stack-overflow text-white"/>
-            </a>
-            <!-- Youtube -->
-            <a
+          <i class="bi bi-stack-overflow text-white"/>
+        </a>
+        <!-- Youtube -->
+        <a
           class="btn m-1"
           style="background-color: #ed302f;"
           href="#!"
           role="button"
         >
-               <i class="bi bi-youtube text-white"/>
-            </a>
-            <!-- Slack -->
-            <a
+          <i class="bi bi-youtube text-white"/>
+        </a>
+        <!-- Slack -->
+        <a
           class="btn m-1"
           style="background-color: #481449;"
           href="#!"
           role="button"
         >
-               <i class="bi bi-slack text-white"/>
-            </a>
-            <!-- Dribbble -->
-            <a
+          <i class="bi bi-slack text-white"/>
+        </a>
+        <!-- Dribbble -->
+        <a
           class="btn m-1"
           style="background-color: #ec4a89;"
           href="#!"
           role="button"
         >
-               <i class="bi bi-dribbble text-white"/>
-            </a>
-            <!-- Reddit -->
-            <a
+          <i class="bi bi-dribbble text-white"/>
+        </a>
+        <!-- Reddit -->
+        <a
           class="btn m-1"
           style="background-color: #ff4500;"
           href="#!"
           role="button"
         >
-               <i class="bi bi-reddit text-white"/>
-            </a>
-            <!-- Whatsapp -->
-            <a
+          <i class="bi bi-reddit text-white"/>
+        </a>
+        <!-- Whatsapp -->
+        <a
           class="btn m-1"
           style="background-color: #25d366;"
           href="#!"
           role="button"
         >
-               <i class="bi bi-whatsapp text-white"/>
-            </a>
-         </p>
-         <p
-        class="p-3"
-      >Lorem ipsum dolor sit amet consectetur adipisicing elit. Sunt
+          <i class="bi bi-whatsapp text-white"/>
+        </a>
+      </p>
+      <p class="p-3">
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Sunt
         distinctio earum repellat quaerat voluptatibus placeat nam,
         commodi optio pariatur est quia magnam eum harum corrupti dicta,
         aliquam sequi voluptate quas.</p>
-         <p class="p-3">
-            <small>© 2023</small>
-         </p>
-      </div>
-   </div>
+      <p class="p-3">
+        <small>© 2023</small>
+      </p>
+    </div>
+  </div>
 </div>
 <!-- Footer -->

--- a/includes/bs-footer-example.xml
+++ b/includes/bs-footer-example.xml
@@ -1,47 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!-- Footer -->
 <div class="container text-center">
-  <div class="row">
-    <div class="col">
-      <!-- Social media -->
-      <p class="text-center p-3">
-        <!-- GitHub -->
-        <a
+   <div class="row">
+      <div class="col">
+         <!-- Social media -->
+         <p class="text-center p-3">
+            <!-- GitHub -->
+            <a
           class="btn m-1"
           href="#!"
           role="button"
           style="background-color: #333333;"
         >
-          <i class="bi bi-github text-white"/>
-        </a>
-        <!-- Linkedin -->
-        <a
+               <i class="bi bi-github text-white"/>
+            </a>
+            <!-- Linkedin -->
+            <a
           class="btn m-1"
           href="#!"
           role="button"
           style="background-color: #0082ca;"
         >
-          <i class="bi bi-linkedin text-white"/>
-        </a>
-        <!-- Twitter -->
-        <a
+               <i class="bi bi-linkedin text-white"/>
+            </a>
+            <!-- Twitter -->
+            <a
           class="btn m-1"
           href="#!"
           role="button"
           style="background-color: #55acee;"
         >
-          <i class="bi bi-twitter text-white"/>
-        </a>
-      </p>
-      <p class="p-3">
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Sunt
+               <i class="bi bi-twitter text-white"/>
+            </a>
+            <!-- Facebook -->
+            <a
+          class="btn m-1"
+          style="background-color: #3b5998;"
+          href="#!"
+          role="button"
+        >
+               <i class="bi bi-facebook text-white"/>
+            </a>
+            <!-- Google -->
+            <a
+          class="btn m-1"
+          style="background-color: #dd4b39;"
+          href="#!"
+          role="button"
+        >
+               <i class="bi bi-google text-white"/>
+            </a>
+            <!-- Instagram -->
+            <a
+          class="btn m-1"
+          style="background-color: #ac2bac;"
+          href="#!"
+          role="button"
+        >
+               <i class="bi bi-instagram text-white"/>
+            </a>
+            <!-- Pinterest -->
+            <a
+          class="btn m-1"
+          style="background-color: #c61118;"
+          href="#!"
+          role="button"
+        >
+               <i class="bi bi-pinterest text-white"/>
+            </a>
+            <!-- Stack overflow -->
+            <a
+          class="btn m-1"
+          style="background-color: #ffac44;"
+          href="#!"
+          role="button"
+        >
+               <i class="bi bi-stack-overflow text-white"/>
+            </a>
+            <!-- Youtube -->
+            <a
+          class="btn m-1"
+          style="background-color: #ed302f;"
+          href="#!"
+          role="button"
+        >
+               <i class="bi bi-youtube text-white"/>
+            </a>
+            <!-- Slack -->
+            <a
+          class="btn m-1"
+          style="background-color: #481449;"
+          href="#!"
+          role="button"
+        >
+               <i class="bi bi-slack text-white"/>
+            </a>
+            <!-- Dribbble -->
+            <a
+          class="btn m-1"
+          style="background-color: #ec4a89;"
+          href="#!"
+          role="button"
+        >
+               <i class="bi bi-dribbble text-white"/>
+            </a>
+            <!-- Reddit -->
+            <a
+          class="btn m-1"
+          style="background-color: #ff4500;"
+          href="#!"
+          role="button"
+        >
+               <i class="bi bi-reddit text-white"/>
+            </a>
+            <!-- Whatsapp -->
+            <a
+          class="btn m-1"
+          style="background-color: #25d366;"
+          href="#!"
+          role="button"
+        >
+               <i class="bi bi-whatsapp text-white"/>
+            </a>
+         </p>
+         <p
+        class="p-3"
+      >Lorem ipsum dolor sit amet consectetur adipisicing elit. Sunt
         distinctio earum repellat quaerat voluptatibus placeat nam,
         commodi optio pariatur est quia magnam eum harum corrupti dicta,
-        aliquam sequi voluptate quas.
-      </p>
-      <p class="p-3">
-        <small>© 2023</small>
-      </p>
-    </div>
-  </div>
+        aliquam sequi voluptate quas.</p>
+         <p class="p-3">
+            <small>© 2023</small>
+         </p>
+      </div>
+   </div>
 </div>
 <!-- Footer -->

--- a/includes/bs-footer-example.xml
+++ b/includes/bs-footer-example.xml
@@ -23,6 +23,15 @@
         >
           <i class="bi bi-linkedin text-white"/>
         </a>
+        <!-- Mastodon -->
+        <a
+          class="btn m-1"
+          href="#!"
+          role="button"
+          style="background-color: #563acc;"
+        >
+          <i class="bi bi-mastodon text-white"/>
+        </a>
         <!-- Twitter -->
         <a
           class="btn m-1"

--- a/includes/bs-footer-example.xml
+++ b/includes/bs-footer-example.xml
@@ -6,8 +6,7 @@
       <p class="text-center p-3">
         <!-- GitHub -->
         <a
-          class="btn btn-primary btn-floating m-1"
-          style="background-color: #333333"
+          class="btn btn-primary m-1"
           href="#!"
           role="button"
         >
@@ -15,8 +14,7 @@
         </a>
         <!-- Linkedin -->
         <a
-          class="btn btn-primary btn-floating m-1"
-          style="background-color: #0082ca"
+          class="btn btn-primary m-1"
           href="#!"
           role="button"
         >
@@ -24,8 +22,7 @@
         </a>
         <!-- Twitter -->
         <a
-          class="btn btn-primary btn-floating m-1"
-          style="background-color: #55acee"
+          class="btn btn-primary m-1"
           href="#!"
           role="button"
         >

--- a/includes/bs-footer-example.xml
+++ b/includes/bs-footer-example.xml
@@ -5,16 +5,31 @@
       <!-- Social media -->
       <p class="text-center p-3">
         <!-- GitHub -->
-        <a class="btn btn-primary m-1" href="#!" role="button">
-          <i class="bi bi-github"/>
+        <a
+          class="btn m-1"
+          href="#!"
+          role="button"
+          style="background-color: #333333;"
+        >
+          <i class="bi bi-github text-white"/>
         </a>
         <!-- Linkedin -->
-        <a class="btn btn-primary m-1" href="#!" role="button">
-          <i class="bi bi-linkedin"/>
+        <a
+          class="btn m-1"
+          href="#!"
+          role="button"
+          style="background-color: #0082ca;"
+        >
+          <i class="bi bi-linkedin text-white"/>
         </a>
         <!-- Twitter -->
-        <a class="btn btn-primary m-1" href="#!" role="button">
-          <i class="bi bi-twitter"/>
+        <a
+          class="btn m-1"
+          href="#!"
+          role="button"
+          style="background-color: #55acee;"
+        >
+          <i class="bi bi-twitter text-white"/>
         </a>
       </p>
       <p class="p-3">

--- a/insertParameters.xml
+++ b/insertParameters.xml
@@ -75,6 +75,11 @@
     if:set="bootstrap.css.carousel.caption"
   />
   <param
+    name="BOOTSTRAP_CSS_FOOTER"
+    expression="${bootstrap.css.footer}"
+    if:set="bootstrap.css.footer"
+  />
+  <param
     name="BOOTSTRAP_CSS_TABS"
     expression="${bootstrap.css.tabs}"
     if:set="bootstrap.css.tabs"

--- a/plugin.xml
+++ b/plugin.xml
@@ -151,6 +151,11 @@
       desc="Bootstrap classes for carousel indicators"
     />
     <param
+      name="bootstrap.css.footer"
+      type="string"
+      desc="Bootstrap classes for footers"
+    />
+    <param
       name="bootstrap.css.tabs"
       type="string"
       desc="Bootstrap classes for tabbed dialog components"

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -481,7 +481,13 @@
       <p>The default header file <filepath>includes/bs-navbar-default.hdr.xml</filepath> uses the Bootstrap primary
         (blue) background color for the
         <xref href="https://getbootstrap.com/docs/5.3/examples/navbars/" format="html" scope="external">navbar
-          component</xref>, and provides a theme menu to toggle <xref href="./dark-mode.dita">dark mode</xref>.</p>
+          component</xref>, and provides a theme menu to toggle <xref
+          href="./dark-mode.dita"
+        >dark mode</xref>.  Bootstrap itself offers additional <xref
+          href="https://getbootstrap.com/docs/5.3/examples/headers/"
+          format="html"
+          scope="external"
+        >header examples</xref>.</p>
       <p>You can edit a copy of this file to adjust the content of the global navigation. To override the global
         navigation with your own header, pass a custom header file to the <cmdname>dita</cmdname> command via the
           <parmname>--args.hdr</parmname> parameter:</p>
@@ -500,7 +506,11 @@
           href="https://github.com/infotexture/dita-bootstrap/blob/develop/includes/bs-footer-example.xml"
           format="html"
           scope="external"
-        >footer file</xref>. To add a footer to the generated output, pass a custom
+        >footer file</xref> and Bootstrap also offers additional <xref
+          href="https://getbootstrap.com/docs/5.3/examples/headers/"
+          format="html"
+          scope="external"
+        >examples</xref>. To add a footer to the generated output, pass a custom
         footer file to the <cmdname>dita</cmdname> command via the <parmname>--args.ftr</parmname> parameter:</p>
       <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
         >path/to/your.ditamap</filepath> \

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -632,6 +632,7 @@
       <indexterm><parmname>--bootstrap.css.carousel</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.carousel.caption</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.carousel.indicators</parmname></indexterm>
+      <indexterm><parmname>--bootstrap.css.footer</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.table</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.tabs</parmname></indexterm>
       <indexterm><parmname>--bootstrap.css.tabs.vertical</parmname></indexterm>
@@ -708,6 +709,10 @@
         <li>
           <parmname>--bootstrap.css.figure.caption</parmname> – common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements within <xmlelement>fig</xmlelement> elements
+        </li>
+        <li>
+          <parmname>--bootstrap.css.footer</parmname> – common utility classes for the HTML
+            <xmlelement>footer</xmlelement> element
         </li>
         <li>
           <parmname>--bootstrap.css.figure.image</parmname> – common Bootstrap utility classes for DITA
@@ -838,7 +843,7 @@
             scope="external"
           >dark mode</xref> toggler</li>
       </ul>
-      <p>Opt-in breadcrumbs and menu bars can be added using the following parameters:</p>
+      <p>Opt-in breadcrumbs and menu bars and other modifiers can be added using the following parameters:</p>
       <ul>
         <li>
           <parmname>--args.breadcrumbs</parmname> – enable Bootstrap

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -711,12 +711,12 @@
             <xmlelement>title</xmlelement> elements within <xmlelement>fig</xmlelement> elements
         </li>
         <li>
-          <parmname>--bootstrap.css.footer</parmname> – common utility classes for the HTML
-            <xmlelement>footer</xmlelement> element
-        </li>
-        <li>
           <parmname>--bootstrap.css.figure.image</parmname> – common Bootstrap utility classes for DITA
             <xmlelement>image</xmlelement> elements within <xmlelement>fig</xmlelement> elements
+        </li>
+        <li>
+          <parmname>--bootstrap.css.footer</parmname> – common utility classes for the HTML
+            <xmlelement>footer</xmlelement> element
         </li>
         <li>
           <parmname>--bootstrap.css.nav.parent</parmname> – common Bootstrap utility classes for ancestors of active


### PR DESCRIPTION
Autostyle the `<footer>` element using standard Bootstrap - e.g. `simplex`

<img width="495" alt="Screenshot 2023-09-01 at 12 18 38" src="https://github.com/infotexture/dita-bootstrap/assets/3439249/dc59d4d6-883c-44ec-99aa-32b4c3c47221">

- Update XSL with a sane default.
- Add `bootstrap.css.footer` paramter
- Update documentation
-  Update sample footer
- Remove custom CSS from GitHub Action