### PR TITLE
Add divider option

### DIFF
--- a/Customization/xsl/nav.xsl
+++ b/Customization/xsl/nav.xsl
@@ -56,18 +56,18 @@
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template name="nav-spacer">
+  <xsl:template name="nav-divider">
     <xsl:if
-      test="./*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/othermeta ') and (@name='spacer')]"
+      test="./*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/othermeta ') and (@name='divider')]"
     >
       <xsl:variable
         name="content"
-        select="./*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/othermeta ') and (@name='spacer')]/@content"
+        select="./*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/othermeta ') and (@name='divider')]/@content"
       />
       <li>
         <hr class="m-1"/>
         <xsl:if test="not($content = '')">
-          <span class="ps-3 bd-spacer">
+          <span class="ps-3 bd-divider">
             <xsl:value-of disable-output-escaping="yes" select="$content"/>
           </span>
         </xsl:if>
@@ -666,7 +666,7 @@
       <xsl:call-template name="get-show-menu"/>
     </xsl:variable>
     <xsl:if test="not($BOOTSTRAP_MENUBAR_TOC = 'yes')">
-      <xsl:call-template name="nav-spacer"/>
+      <xsl:call-template name="nav-divider"/>
     </xsl:if>
     <li>
       <xsl:choose>
@@ -842,7 +842,7 @@
                   <xsl:variable name="title">
                     <xsl:apply-templates select="." mode="get-navtitle"/>
                   </xsl:variable>
-                  <xsl:call-template name="nav-spacer"/>
+                  <xsl:call-template name="nav-divider"/>
                   <li role="none">
                     <a role="menuitem">
                       <xsl:call-template name="nav-attributes">

--- a/Customization/xsl/nav.xsl
+++ b/Customization/xsl/nav.xsl
@@ -56,6 +56,26 @@
     </xsl:choose>
   </xsl:template>
 
+  <xsl:template name="nav-spacer">
+    <xsl:if
+      test="./*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/othermeta ') and (@name='spacer')]"
+    >
+      <xsl:variable
+        name="content"
+        select="./*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/othermeta ') and (@name='spacer')]/@content"
+      />
+      <li>
+        <hr class="m-1"/>
+        <xsl:if test="not($content = '')">
+          <span class="ps-3 bd-spacer">
+            <xsl:value-of disable-output-escaping="yes" select="$content"/>
+          </span>
+        </xsl:if>
+      </li>
+    </xsl:if>
+</xsl:template>
+
+
   <xsl:template name="nav-icon">
       <xsl:if
       test="./*[contains(@class, ' map/topicmeta ')]/*[contains(@class, ' topic/othermeta ') and (@name='icon')]"
@@ -128,7 +148,14 @@
   </xsl:template>
 
   <xsl:template name="offcanvas-sidebar">
-    <div class="offcanvas-lg offcanvas-start" tabindex="-1" id="bdSidebar" aria-labelledby="bdSidebarOffcanvasLabel" aria-modal="true" role="dialog">
+    <div
+      class="offcanvas-lg offcanvas-start"
+      tabindex="-1"
+      id="bdSidebar"
+      aria-labelledby="bdSidebarOffcanvasLabel"
+      aria-modal="true"
+      role="dialog"
+    >
       <div class="offcanvas-header border-bottom">
         <h5 class="offcanvas-title" id="bdSidebarOffcanvasLabel">
           <xsl:choose>
@@ -150,11 +177,19 @@
               <xsl:value-of select="//*[contains(@class, ' map/map ')]/@title"/>
             </xsl:when>
             <xsl:otherwise>
-              <xsl:value-of select="/descendant::*[contains(@class, ' topic/topic ')][1]/*[contains(@class, ' topic/title ')]"/>
+              <xsl:value-of
+                select="/descendant::*[contains(@class, ' topic/topic ')][1]/*[contains(@class, ' topic/title ')]"
+              />
             </xsl:otherwise>
           </xsl:choose>
         </h5>
-        <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close" data-bs-target="#bdSidebar"></button>
+        <button
+          type="button"
+          class="btn-close"
+          data-bs-dismiss="offcanvas"
+          aria-label="Close"
+          data-bs-target="#bdSidebar"
+        />
       </div>
       <div class="offcanvas-body">
         <xsl:call-template name="sidebar-content"/>
@@ -630,6 +665,9 @@
     <xsl:variable name="show-menu">
       <xsl:call-template name="get-show-menu"/>
     </xsl:variable>
+    <xsl:if test="not($BOOTSTRAP_MENUBAR_TOC = 'yes')">
+      <xsl:call-template name="nav-spacer"/>
+    </xsl:if>
     <li>
       <xsl:choose>
         <xsl:when test="$BOOTSTRAP_MENUBAR_TOC = 'yes' and count(ancestor::*/@href) eq 0 and not($show-menu = 'show')">
@@ -804,6 +842,7 @@
                   <xsl:variable name="title">
                     <xsl:apply-templates select="." mode="get-navtitle"/>
                   </xsl:variable>
+                  <xsl:call-template name="nav-spacer"/>
                   <li role="none">
                     <a role="menuitem">
                       <xsl:call-template name="nav-attributes">

--- a/css/collapsible-toc.css
+++ b/css/collapsible-toc.css
@@ -32,7 +32,7 @@
   color: var(--bs-link-hover-color);
 }
 
-.bd-links span.bd-spacer:hover {
+.bd-links span.bd-divider:hover {
   color: var(--bs-body-color);
 }
 
@@ -62,7 +62,7 @@
   font-size: 0.875em;
 }
 
-.bd-spacer {
+.bd-divider {
   font-size: 0.875em;
   font-weight: 600;
 }

--- a/css/collapsible-toc.css
+++ b/css/collapsible-toc.css
@@ -32,6 +32,10 @@
   color: var(--bs-link-hover-color);
 }
 
+.bd-links span.bd-spacer:hover {
+  color: var(--bs-body-color);
+}
+
 @media (min-width: 768px) {
   .bd-links {
     position: -webkit-sticky;
@@ -56,6 +60,11 @@
 
 .bd-links li li a {
   font-size: 0.875em;
+}
+
+.bd-spacer {
+  font-size: 0.875em;
+  font-weight: 600;
 }
 
 .bd-links .btn {

--- a/sample/document.ditamap
+++ b/sample/document.ditamap
@@ -21,6 +21,7 @@
       <othermeta name="icon" content="bi-grid-fill"/>
       <othermeta name="icon-style" content="color: var(--bs-teal)"/>
     </topicmeta>
+    <topicref navtitle="Navigation Menus" format="dita" type="topic" href="nav.dita"/>
     <topicref navtitle="Grid" format="dita" type="topic" href="grid.dita"/>
     <topicref navtitle="Right-to-Left Languages" format="dita" href="rtl.dita" locktitle="yes"/>
   </chapter>

--- a/sample/document.ditamap
+++ b/sample/document.ditamap
@@ -85,7 +85,7 @@
     <topicref navtitle="Search Box" format="dita" type="topic" href="search-box.dita">
       <topicmeta>
         <othermeta name="icon" content="bi-search"/>
-        <othermeta name="spacer" content="Additional Plug-ins"/>
+        <othermeta name="divider" content="Additional Plug-ins"/>
       </topicmeta>
     </topicref>
     <topicref navtitle="Offline Mode" format="dita" type="topic" href="offline.dita">

--- a/sample/document.ditamap
+++ b/sample/document.ditamap
@@ -85,6 +85,7 @@
     <topicref navtitle="Search Box" format="dita" type="topic" href="search-box.dita">
       <topicmeta>
         <othermeta name="icon" content="bi-search"/>
+        <othermeta name="spacer" content="Additional Plug-ins"/>
       </topicmeta>
     </topicref>
     <topicref navtitle="Offline Mode" format="dita" type="topic" href="offline.dita">

--- a/sample/icons.dita
+++ b/sample/icons.dita
@@ -16,6 +16,18 @@
     <xref href="https://feathericons.com/" format="html" scope="external">Feather</xref> and
     <xref href="https://octicons.github.com/" format="html" scope="external">Octicons</xref> can also be added using
     command line parameters.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>Icons</indexterm>
+        <indexterm>CSS
+          <indexterm><xmlatt>outputclass</xmlatt></indexterm>
+        </indexterm>
+        <indexterm><xmlatt>otherprops</xmlatt></indexterm>
+        <indexterm><xmlelement>othermeta</xmlelement></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
   <body outputclass="language-markup">
     <section>
       <title>Bootstrap Icons</title>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -514,9 +514,13 @@
           format="html"
           scope="external"
         >navigation parameter</xref>
-        <parmname>--nav-toc</parmname> to add a styled navigation <xref href="./nav.dita" format="dita"> sidebar</xref> to the output.
+        <parmname>--nav-toc</parmname> to add a styled navigation <xref
+          href="./nav.dita"
+          format="dita"
+        > sidebar</xref> to the output.
       </p>
-      <p>As of version 5.3.1, the plug-in provides five new <parmname>--nav-toc</parmname> options to style the table of contents navigation with
+      <p>As of version 5.3.1, the plug-in provides five new <parmname
+        >--nav-toc</parmname> options to style the table of contents navigation with
         either the Bootstrap
         <xref href="https://getbootstrap.com/docs/5.3/components/list-group/" format="html" scope="external">list
           group</xref> component,

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -474,7 +474,7 @@
       </p>
     </section>
     <section>
-      <title>Customizing headers and footers</title>
+      <title>Customizing headers, footers and sidebars</title>
       <indexterm><parmname>--args.hdr</parmname></indexterm>
       <indexterm><parmname>--args.ftr</parmname></indexterm>
       <p>The plug-in includes a default static navigation menu with a project name and global link placeholders.</p>
@@ -506,25 +506,17 @@
         >path/to/your.ditamap</filepath> \
      <parmname>--format</parmname>=<option>html5-bootstrap</option> \
      <parmname>--args.ftr</parmname>=<filepath>path/to/your-footer.xml</filepath></codeblock>
-    </section>
 
-    <section>
-      <title>Navigation menu</title>
-      <indexterm><parmname>--nav-toc</parmname></indexterm>
-      <indexterm><parmname>--menubar-toc.include</parmname></indexterm>
-      <p>The plug-in extends the standard HTML5 table of contents (ToC)
+      <p>
+        The plug-in extends the standard HTML5 table of contents (ToC)
         <xref
           href="https://www.dita-ot.org/dev/parameters/parameters-html5.html#html5__nav-toc"
           format="html"
           scope="external"
         >navigation parameter</xref>
-        <parmname>--nav-toc</parmname> to add styled list groups to the navigation menu. (The navigation is rendered as
-        a sidebar in desktop browsers and above the content on smaller devices.)</p>
-      <p>By default, the plug-in uses the <option>partial</option> option to include the current topic in the ToC along
-        with its parents, siblings and children. As with the default HTML5 plug-in, the <option>full</option> option can
-        also be used to generate a complete ToC for the entire map, or <option>none</option> to disable the table of
-        contents entirely.</p>
-      <p>As of version 5.3.1, the plug-in provides five new options to style the table of contents navigation with
+        <parmname>--nav-toc</parmname> to add a styled navigation <xref href="./nav.dita" format="dita"> sidebar</xref> to the output.
+      </p>
+      <p>As of version 5.3.1, the plug-in provides five new <parmname>--nav-toc</parmname> options to style the table of contents navigation with
         either the Bootstrap
         <xref href="https://getbootstrap.com/docs/5.3/components/list-group/" format="html" scope="external">list
           group</xref> component,
@@ -537,90 +529,36 @@
           href="https://getbootstrap.com/docs/5.3/components/collapse/"
           format="html"
           scope="external"
-        >collapsible</xref> menus.
+        >collapsible</xref> menus. The following new options are available:
       </p>
       <ul>
         <li>
-          <option>list-group-full</option> – Styled full ToC within a Bootstrap list group </li>
+          <option>nav-pill-full</option> – Styled full ToC using nav-pills
+        </li>
         <li>
-          <option>list-group-partial</option> – Partial ToC with the current topic, parents, siblings, and children in a
-          list group </li>
+          <option>nav-pill-partial</option> – Styled partial ToC using nav-pills
+        </li>
         <li>
-          <option>nav-pill-full</option> – Styled full ToC using Bootstrap nav-pills </li>
+          <option>list-group-full</option> – Styled full ToC within a list group
+        </li>
         <li>
-          <option>nav-pill-partial</option> – Partial ToC with the current topic, parents, siblings, and children using
-          Bootstrap nav-pills </li>
+          <option>list-group-partial</option> – Styled partial ToC within a list group
+        </li>
         <li>
-          <option>collapsible</option> – Styled full ToC using collapsible list elements </li>
+          <option>collapsible</option> - tyled full ToC with collapsible elements
+        </li>
       </ul>
-      <p>To use these options, pass the desired value to the <cmdname>dita</cmdname> command via the
-          <parmname>--nav-toc</parmname> parameter:</p>
       <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
         >path/to/your.ditamap</filepath> \
      <parmname>--format</parmname>=<option>html5-bootstrap</option> \
-     <parmname>--nav-toc</parmname>=<option>list-group-partial</option></codeblock>
-      <ol outputclass="carousel pt-2" otherprops="indicators(true)">
-        <li>
-          <fig>
-            <title><option>full</option> – Unstyled full TOC</title>
-            <image href="./src/full.png"/>
-          </fig>
-        </li>
-        <li>
-          <fig>
-            <title><option>partial</option> – Unstyled partial TOC</title>
-            <image href="./src/partial.png"/>
-          </fig>
-        </li>
-        <li>
-          <fig>
-            <title><option>nav-pill-full</option> – Styled full ToC using nav-pills</title>
-            <image href="./src/nav-pill-full.png"/>
-          </fig>
-        </li>
-        <li>
-          <fig>
-            <title><option>nav-pill-partial</option> – Styled partial ToC using nav-pills</title>
-            <image href="./src/nav-pill-partial.png"/>
-          </fig>
-        </li>
-        <li>
-          <fig>
-            <title><option>list-group-full</option> – Styled full ToC within a list group</title>
-            <image href="./src/list-group-full.png"/>
-          </fig>
-        </li>
-        <li>
-          <fig>
-            <title><option>list-group-partial</option> – Styled partial ToC within a list group</title>
-            <image href="./src/list-group-partial.png"/>
-          </fig>
-        </li>
-        <li>
-          <fig>
-            <title><option>collapsible</option> – Styled full ToC with collapsible elements</title>
-            <image href="./src/collapsible.png"/>
-          </fig>
-        </li>
-      </ol>
-      <note outputclass="alert-primary">For an example of <option>collapsible</option> styling, see the output at
+     <parmname>--nav-toc</parmname>=<option>&lt;sidebar-style&gt;</option></codeblock>
+
+       <note outputclass="alert-primary">For an example of <option>collapsible</option> styling, see the output at
         <xref
           href="https://infotexture.github.io/dita-bootstrap/"
           format="html"
           scope="external"
         >infotexture.github.io/dita-bootstrap</xref>. </note>
-      <p>Additionally, the first-level navigation menu can be switched to a horizontal Bootstrap navbar to reduce the
-        depth of the ToC. To use this option, add the <parmname>--menubar-toc.include</parmname>=<option
-        >yes</option> parameter to the
-          <cmdname>dita</cmdname> command:</p>
-      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
-        >path/to/your.ditamap</filepath> \
-     <parmname>--format</parmname>=<option>html5-bootstrap</option> \
-     <parmname>--nav-toc</parmname>=<option>list-group-partial</option> \
-     <parmname>--menubar-toc.include</parmname>=<option>yes</option></codeblock>
-      <fig>
-        <image scalefit="yes" href="./src/menubar-toc.png"/>
-      </fig>
     </section>
     <section>
       <title>Common Bootstrap utility classes</title>

--- a/sample/nav.dita
+++ b/sample/nav.dita
@@ -32,7 +32,8 @@
           format="html"
           scope="external"
         >navigation parameter</xref>
-        <parmname>--nav-toc</parmname> to add table of contents items to the navigation sidebar. (The navigation is rendered as
+        <parmname
+        >--nav-toc</parmname> to add table of contents items to the navigation sidebar. (The navigation is rendered as
         a sidebar in desktop browsers and collapsible  on smaller devices.)</p>
       <p>By default, the plug-in uses the <option>partial</option> option to include the current topic in the ToC along
         with its parents, siblings and children. As with the default HTML5 plug-in, the <option>full</option> option can
@@ -119,7 +120,8 @@
       </ol>
 
       <p>
-        The sidebar is hidden by default on mobile. To ensure that the sidebar content can be accessed, the header file must include the following toggle with <xmlatt>data-bs-target="#bdSidebar"</xmlatt>
+        The sidebar is hidden by default on mobile. To ensure that the sidebar content can be accessed, the header file must include the following toggle with <xmlatt
+        >data-bs-target="#bdSidebar"</xmlatt>
         and <xmlatt>data-bs-toggle="offcanvas"</xmlatt>
       </p>
       <codeblock outputclass="language-xml">&lt;div class="bd-navbar-toggle"&gt;
@@ -154,11 +156,14 @@
           format="html"
           scope="external"
         >Dividers</xref> can be added to items rendered in collapsible sidebars and menus by adding the
-         <xmlelement>othermeta name="divider"</xmlelement> element with the <xmlelement>topicmeta</xmlelement> of the <filepath>*.ditamap</filepath>. The content of the
+         <xmlelement>othermeta name="divider"</xmlelement> element with the <xmlelement
+        >topicmeta</xmlelement> of the <filepath>*.ditamap</filepath>. The content of the
          <xmlatt>content</xmlatt> (if any) is rendered after the divider bar itself.
       </p>
     </section>
-    <codeblock outputclass="language-xml">&lt;topicref navtitle="Search Box" format="dita" type="topic" href="search-box.dita">
+    <codeblock
+      outputclass="language-xml"
+    >&lt;topicref navtitle="Search Box" format="dita" type="topic" href="search-box.dita">
   &lt;topicmeta&gt;
     &lt;othermeta name="divider" content="Additional Plug-ins"/&gt;
   &lt;/topicmeta&gt;

--- a/sample/nav.dita
+++ b/sample/nav.dita
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE topic PUBLIC "-//OASIS//DTD DITA Topic//EN" "topic.dtd">
+<!-- Within the sample documentation, where necessary, the texts describing the
+   usage of each component have been copied directly from the official Bootstrap
+   5.3 documentation (found at https://getbootstrap.com/docs/5.3), however DITA
+   markup is used throughout the examples describing how to implement these
+   components correctly using outputclass.
+
+   This work, is a derivative of "Bootstrap 5.3 docs" by Twitter, Inc.
+   and the Bootstrap Authors, and used under CC BY 3.0. See the accompanying LICENSE
+   file for applicable licenses.-->
+<topic id="navigation">
+  <title>Navigation Menus</title>
+  <shortdesc>Add a responsive Bootstrap styled table of contents to your HTML output.</shortdesc>
+  <prolog>
+    <metadata>
+      <keywords>
+        <indexterm>Sidebar</indexterm>
+        <indexterm>Menu</indexterm>
+        <indexterm><parmname>--nav-toc</parmname></indexterm>
+        <indexterm><parmname>--menubar-toc.include</parmname></indexterm>
+        <indexterm><xmlelement>othermeta</xmlelement></indexterm>
+      </keywords>
+    </metadata>
+  </prolog>
+  <body outputclass="language-markup">
+   <section>
+      <title>Sidebar</title>
+      <p>The plug-in extends the standard HTML5 table of contents (ToC)
+        <xref
+          href="https://www.dita-ot.org/dev/parameters/parameters-html5.html#html5__nav-toc"
+          format="html"
+          scope="external"
+        >navigation parameter</xref>
+        <parmname>--nav-toc</parmname> to add table of contents items to the navigation sidebar. (The navigation is rendered as
+        a sidebar in desktop browsers and collapsible  on smaller devices.)</p>
+      <p>By default, the plug-in uses the <option>partial</option> option to include the current topic in the ToC along
+        with its parents, siblings and children. As with the default HTML5 plug-in, the <option>full</option> option can
+        also be used to generate a complete ToC for the entire map, or <option>none</option> to disable the table of
+        contents entirely.</p>
+      <p>As of version 5.3.1, the plug-in provides five new options to style the table of contents navigation with
+        either the Bootstrap
+        <xref href="https://getbootstrap.com/docs/5.3/components/list-group/" format="html" scope="external">list
+          group</xref> component,
+        <xref
+          href="https://getbootstrap.com/docs/5.3/components/navs-tabs/#pills"
+          format="html"
+          scope="external"
+        >nav-pills</xref>, or
+         <xref
+          href="https://getbootstrap.com/docs/5.3/components/collapse/"
+          format="html"
+          scope="external"
+        >collapsible</xref> menus.
+      </p>
+      <ul>
+        <li>
+          <option>list-group-full</option> – Styled full ToC within a Bootstrap list group </li>
+        <li>
+          <option>list-group-partial</option> – Partial ToC with the current topic, parents, siblings, and children in a
+          list group </li>
+        <li>
+          <option>nav-pill-full</option> – Styled full ToC using Bootstrap nav-pills </li>
+        <li>
+          <option>nav-pill-partial</option> – Partial ToC with the current topic, parents, siblings, and children using
+          Bootstrap nav-pills </li>
+        <li>
+          <option>collapsible</option> – Styled full ToC using collapsible list elements </li>
+      </ul>
+      <p>To use these options, pass the desired value to the <cmdname>dita</cmdname> command via the
+          <parmname>--nav-toc</parmname> parameter:</p>
+      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
+        >path/to/your.ditamap</filepath> \
+     <parmname>--format</parmname>=<option>html5-bootstrap</option> \
+     <parmname>--nav-toc</parmname>=<option>list-group-partial</option></codeblock>
+      <ol outputclass="carousel pt-2" otherprops="indicators(true)">
+        <li>
+          <fig>
+            <title><option>full</option> – Unstyled full TOC</title>
+            <image href="./src/full.png"/>
+          </fig>
+        </li>
+        <li>
+          <fig>
+            <title><option>partial</option> – Unstyled partial TOC</title>
+            <image href="./src/partial.png"/>
+          </fig>
+        </li>
+        <li>
+          <fig>
+            <title><option>nav-pill-full</option> – Styled full ToC using nav-pills</title>
+            <image href="./src/nav-pill-full.png"/>
+          </fig>
+        </li>
+        <li>
+          <fig>
+            <title><option>nav-pill-partial</option> – Styled partial ToC using nav-pills</title>
+            <image href="./src/nav-pill-partial.png"/>
+          </fig>
+        </li>
+        <li>
+          <fig>
+            <title><option>list-group-full</option> – Styled full ToC within a list group</title>
+            <image href="./src/list-group-full.png"/>
+          </fig>
+        </li>
+        <li>
+          <fig>
+            <title><option>list-group-partial</option> – Styled partial ToC within a list group</title>
+            <image href="./src/list-group-partial.png"/>
+          </fig>
+        </li>
+        <li>
+          <fig>
+            <title><option>collapsible</option> – Styled full ToC with collapsible elements</title>
+            <image href="./src/collapsible.png"/>
+          </fig>
+        </li>
+      </ol>
+
+      <p>
+        The sidebar is hidden by default on mobile. To ensure that the sidebar content can be accessed, the header file must include the following toggle.
+      </p>
+      <codeblock outputclass="language-xml">&lt;div class="bd-navbar-toggle"&gt;
+  &lt;button
+    class="navbar-toggler p-2"
+    type="button"
+    data-bs-toggle="offcanvas"
+    data-bs-target="#bdSidebar"
+    aria-controls="bdSidebar"
+    aria-label="Toggle docs navigation"
+  &gt;
+    &lt;i class="bi bi-list"/&gt;
+  &lt;/button&gt;
+&lt;/div&gt;</codeblock>
+
+    </section>
+    <section>
+      <title>Menu bar</title>
+      <p>Additionally, the first-level navigation menu can be switched to a horizontal Bootstrap navbar to reduce the
+        depth of the ToC. To use this option, add the <parmname>--menubar-toc.include</parmname>=<option
+        >yes</option> parameter to the
+          <cmdname>dita</cmdname> command:</p>
+      <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
+        >path/to/your.ditamap</filepath> \
+     <parmname>--format</parmname>=<option>html5-bootstrap</option> \
+     <parmname>--nav-toc</parmname>=<option>list-group-partial</option> \
+     <parmname>--menubar-toc.include</parmname>=<option>yes</option></codeblock>
+      <fig>
+        <image scalefit="yes" href="./src/menubar-toc.png"/>
+      </fig>
+    </section>
+    <section>
+      <title>Dividers</title>
+      <p>
+        <xref
+          href="https://getbootstrap.com/docs/5.3/components/dropdowns/#dividers"
+          format="html"
+          scope="external"
+        >Dividers</xref> can be added to collapsible sidebars and menus by adding the
+         <xmlelement>othermeta name="divider"</xmlelement> element with the <xmlelement>topicmeta</xmlelement> of the <filepath>*.ditamap</filepath>. The content of the
+         <xmlatt>content</xmlatt> (if any) is rendered after the divider bar itself.
+      </p>
+    </section>
+    <codeblock outputclass="language-xml">&lt;topicref navtitle="Search Box" format="dita" type="topic" href="search-box.dita">
+  &lt;topicmeta&gt;
+    &lt;othermeta name="divider" content="Additional Plug-ins"/&gt;
+  &lt;/topicmeta&gt;
+&lt;/topicref&gt;</codeblock>
+  </body>
+</topic>

--- a/sample/nav.dita
+++ b/sample/nav.dita
@@ -119,17 +119,13 @@
       </ol>
 
       <p>
-        The sidebar is hidden by default on mobile. To ensure that the sidebar content can be accessed, the header file must include the following toggle.
+        The sidebar is hidden by default on mobile. To ensure that the sidebar content can be accessed, the header file must include the following toggle with <xmlatt>data-bs-target="#bdSidebar"</xmlatt>
+        and <xmlatt>data-bs-toggle="offcanvas"</xmlatt>
       </p>
       <codeblock outputclass="language-xml">&lt;div class="bd-navbar-toggle"&gt;
-  &lt;button
-    class="navbar-toggler p-2"
-    type="button"
-    data-bs-toggle="offcanvas"
-    data-bs-target="#bdSidebar"
-    aria-controls="bdSidebar"
-    aria-label="Toggle docs navigation"
-  &gt;
+  &lt;button class="navbar-toggler p-2" type="button"
+    data-bs-toggle="offcanvas" data-bs-target="#bdSidebar"
+    aria-controls="bdSidebar" aria-label="Toggle docs navigation"&gt;
     &lt;i class="bi bi-list"/&gt;
   &lt;/button&gt;
 &lt;/div&gt;</codeblock>

--- a/sample/nav.dita
+++ b/sample/nav.dita
@@ -11,7 +11,7 @@
    file for applicable licenses.-->
 <topic id="navigation">
   <title>Navigation Menus</title>
-  <shortdesc>Add a responsive Bootstrap styled table of contents to your HTML output.</shortdesc>
+  <shortdesc>Add a responsive Bootstrap-styled table of contents to your HTML output.</shortdesc>
   <prolog>
     <metadata>
       <keywords>
@@ -122,7 +122,7 @@
       <p>
         The sidebar is hidden by default on mobile. To ensure that the sidebar content can be accessed, the header file must include the following toggle with <xmlatt
         >data-bs-target="#bdSidebar"</xmlatt>
-        and <xmlatt>data-bs-toggle="offcanvas"</xmlatt>
+        and <xmlatt>data-bs-toggle="offcanvas"</xmlatt>:
       </p>
       <codeblock outputclass="language-xml">&lt;div class="bd-navbar-toggle"&gt;
   &lt;button class="navbar-toggler p-2" type="button"
@@ -156,9 +156,9 @@
           format="html"
           scope="external"
         >Dividers</xref> can be added to items rendered in collapsible sidebars and menus by adding the
-         <xmlelement>othermeta name="divider"</xmlelement> element with the <xmlelement
-        >topicmeta</xmlelement> of the <filepath>*.ditamap</filepath>. The content of the
-         <xmlatt>content</xmlatt> (if any) is rendered after the divider bar itself.
+         <xmlelement>othermeta name="divider"</xmlelement> element to the <xmlelement
+        >topicmeta</xmlelement> element in the DITA map topic reference. You can specify a label for the divider via the
+         <xmlatt>content</xmlatt> attribute on the <xmlelement>othermeta</xmlelement> element.
       </p>
     </section>
     <codeblock

--- a/sample/nav.dita
+++ b/sample/nav.dita
@@ -157,7 +157,7 @@
           href="https://getbootstrap.com/docs/5.3/components/dropdowns/#dividers"
           format="html"
           scope="external"
-        >Dividers</xref> can be added to collapsible sidebars and menus by adding the
+        >Dividers</xref> can be added to items rendered in collapsible sidebars and menus by adding the
          <xmlelement>othermeta name="divider"</xmlelement> element with the <xmlelement>topicmeta</xmlelement> of the <filepath>*.ditamap</filepath>. The content of the
          <xmlatt>content</xmlatt> (if any) is rendered after the divider bar itself.
       </p>


### PR DESCRIPTION
Add `  <othermeta name="spacer".../>` with or without additional content.


```xml
<topicref navtitle="Search Box" format="dita" type="topic" href="search-box.dita">
      <topicmeta>
        <othermeta name="icon" content="bi-search"/>
        <othermeta name="spacer" content="Additional Plug-ins"/>
      </topicmeta>
</topicref>
```

### Menu

<img width="171" alt="Screenshot 2023-09-02 at 14 15 54" src="https://github.com/infotexture/dita-bootstrap/assets/3439249/7d2fe08d-316f-49b2-9309-4576109eca01">

### Collapse

<img width="199" alt="Screenshot 2023-09-02 at 14 16 37" src="https://github.com/infotexture/dita-bootstrap/assets/3439249/519c5dd7-0adb-4ea8-9890-2ca359090059">


If `content=""` then a spacer is added with no content.
