### PR TITLE
Move CSS.

### DIFF
--- a/.github/dita-ot/theme.css
+++ b/.github/dita-ot/theme.css
@@ -28,3 +28,8 @@
 .custom-tooltip {
   --bs-tooltip-bg: var(--bs-primary);
 }
+
+/* override part of the Bootstrap color scheme */
+:root {
+  --bs-code-color: var(--bs-secondary-color);
+}

--- a/css/common-bootstrap.css
+++ b/css/common-bootstrap.css
@@ -7,7 +7,6 @@
   --dita-prussian-blue: #1d365d;
   --dita-maroon: #800000;
   --dita-violet: var(--bs-purple);
-  --bs-code-color: var(--bs-secondary-color);
 }
 
 [data-bs-theme='dark'] {


### PR DESCRIPTION
`common-bootstrap.css` is loaded by all users for all layouts. Overriding the default color scheme should not be done here because other users may be using it but altering the SASS value.

_I agree that the standard Bootstrap code color is rather **overwhelming**, :smile:  but it is better to move  this change to the `theme.css` rather than dictating how to set color usage for all users._