### PR TITLE
Add xxl

### DIFF
--- a/.github/dita-ot/header.xml
+++ b/.github/dita-ot/header.xml
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-  <div class="container">
+  <div class="container-xxl">
     <!-- This shows the menu on mobile -->
     <div class="bd-navbar-toggle">
       <button

--- a/includes/hdr.navbar.default.xml
+++ b/includes/hdr.navbar.default.xml
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-  <div class="container">
+  <div class="container-xxl">
     <!-- This shows the menu on mobile -->
     <div class="bd-navbar-toggle">
       <button

--- a/includes/hdr.navbar.example.xml
+++ b/includes/hdr.navbar.example.xml
@@ -1,5 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-body-tertiary">
-  <div class="container">
+  <div class="container-xxl">
     <!-- This shows the menu on mobile -->
     <div class="bd-navbar-toggle">
       <button


### PR DESCRIPTION
Related #89 - you can remove the centring of the menu by amending the class="container". If you prefer it this way, then the equivalent file in the lunr plugin should also be changed.