### PR TITLE
Add bootstrap.css.container.size parameter

### DIFF
--- a/Customization/xsl/nav.xsl
+++ b/Customization/xsl/nav.xsl
@@ -173,7 +173,8 @@
   <!-- Generate a menubar-toc - a menubar as part of the static header -->
   <xsl:template match="*" mode="gen-user-toptoc">
     <div class="bg-body-tertiary">
-      <div class="container-xxl">
+      <div>
+        <xsl:attribute name="class" select="$BOOTSTRAP_CSS_CONTAINER_SIZE"/>
         <nav xsl:use-attribute-sets="menubar-toc">
           <ul class="nav nav-pills" role="menubar">
             <xsl:apply-templates select="$input.map" mode="menubar-toc">

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ The HTML output for the following DITA elements can be annotated with common Boo
 - `bootstrap.css.carousel.caption` – common utility classes for Bootstrap carousel captions
 - `bootstrap.css.carousel.indicators` – common utility classes for Bootstrap carousel indicators
 - `bootstrap.css.codeblock` – common Bootstrap utility classes for DITA `<codeblock>` elements
+- `bootstrap.css.container.size` - defines Bootstrap container class for main layout and menubar-TOC. Options: `container`, `container-fluid`, `container-sm`, `container-md`, `container-lg`, `container-xl`, `container-xxl` (default)
 - `bootstrap.css.dd` – common utility classes for DITA `<dd>` elements
 - `bootstrap.css.dl` – common utility classes for DITA `<dl>` elements
 - `bootstrap.css.dt` – common utility classes for DITA `<dt>` elements

--- a/includes/hdr.navbar.default.xml
+++ b/includes/hdr.navbar.default.xml
@@ -1,4 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+  <!-- Modify -xxl to change container size -->
   <div class="container-xxl">
     <!-- This shows the menu on mobile -->
     <div class="bd-navbar-toggle">

--- a/includes/hdr.navbar.example.xml
+++ b/includes/hdr.navbar.example.xml
@@ -1,4 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-body-tertiary">
+  <!-- Modify -xxl to change container size -->
   <div class="container-xxl">
     <!-- This shows the menu on mobile -->
     <div class="bd-navbar-toggle">

--- a/includes/hdr.topbar.example.xml
+++ b/includes/hdr.topbar.example.xml
@@ -1,4 +1,5 @@
 <nav class="navbar bg-black p-0">
+  <!-- Modify -xxl to change container size -->
   <div class="container-xxl px-4">
     <a class="btn mx-1" href="#!" role="button">
       <i class="bi bi-github text-white"/>

--- a/insertParameters.xml
+++ b/insertParameters.xml
@@ -244,4 +244,9 @@
     expression="${bootstrap.topbar.hdr.path}"
     if:set="bootstrap.topbar.hdr.path"
   />
+  <param
+    name="BOOTSTRAP_CSS_CONTAINER_SIZE"
+    expression="${bootstrap.css.container.size}"
+    if:set="bootstrap.css.container.size"
+  />
 </dummy>

--- a/plugin.xml
+++ b/plugin.xml
@@ -343,6 +343,19 @@
       desc="Specifies an XML file that contains content for the topbar header."
       type="file"
     />
+    <param
+      name="bootstrap.css.container.size"
+      type="enum"
+      desc="Defines Bootstrap container class for main layout and menubar-TOC."
+    >
+      <val>container</val>
+      <val>container-sm</val>
+      <val>container-md</val>
+      <val>container-lg</val>
+      <val>container-xl</val>
+      <val default="true">container-xxl</val>
+      <val>container-fluid</val>
+    </param>
   </transtype>
   <feature extension="ant.import" file="build_dita2html5-bootstrap.xml"/>
   <feature extension="extend.css.process" value="dita-bootstrap.css.copy"/>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -640,6 +640,12 @@
             <xmlelement>codeblock</xmlelement> elements
         </li>
         <li>
+          <parmname>--bootstrap.css.container.size</parmname> – defines Bootstrap container class for main layout and
+           menubar-TOC. Options: <option>container</option>, <option>container-fluid</option>,
+           <option>container-sm</option>, <option>container-md</option>, <option>container-lg</option>,
+           <option>container-xl</option>, <option>container-xxl</option> (default)
+        </li>
+        <li>
           <parmname>--bootstrap.css.dd</parmname> – common Bootstrap utility classes for DITA
             <xmlelement>dd</xmlelement> definition description elements
         </li>

--- a/xsl/html5-bootstrap.xsl
+++ b/xsl/html5-bootstrap.xsl
@@ -21,6 +21,8 @@
   <xsl:param name="BOOTSTRAP_POPOVERS_INCLUDE" select="'yes'"/>
   <!-- Whether to include a scrollspy Toc -->
   <xsl:param name="BOOTSTRAP_SCROLLSPY_TOC" select="'none'"/>
+  <!-- Defines container class for main layout and menubar-TOC -->
+  <xsl:param name="BOOTSTRAP_CSS_CONTAINER_SIZE" select="'container-xxl'"/>
 
   <xsl:import href="plugin:org.dita.html5:xsl/dita2html5.xsl"/>
 
@@ -101,7 +103,12 @@
         <xsl:apply-templates select="." mode="gen-user-toptoc"/>
       </xsl:if>
 
-      <div class="bs-container container-xxl bd-gutter mt-3 my-md-4" id="content">
+      <div>
+        <xsl:attribute
+          name="class"
+          select="concat('bs-container ', $BOOTSTRAP_CSS_CONTAINER_SIZE, ' bd-gutter mt-3 my-md-4')"
+        />
+        <xsl:attribute name="id" select="'content'"/>
         <xsl:call-template name="gen-user-sidetoc"/>
         <xsl:apply-templates select="." mode="addContentToHtmlBodyElement"/>
       </div>


### PR DESCRIPTION
The `bootstrap.css.container.size` parameter defines the size of the main layout div (`id=content`) and the menubar-TOC container. This allows more flexibility to adjust the site layout, and makes it possible to match the layout with a custom header if needed. 

Default value is `container-xxl`.