### PR TITLE
Add Cosmo theme to header.xml and fix light navbar icons

### DIFF
--- a/.github/dita-ot/header.xml
+++ b/.github/dita-ot/header.xml
@@ -201,6 +201,15 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/cosmo/bootstrap.min.css"
+              >
+                Cosmo
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="dropdown-item d-flex align-items-center"
                 data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.3/dist/cyborg/bootstrap.min.css"
               >
                 Cyborg

--- a/includes/hdr.navbar.example.xml
+++ b/includes/hdr.navbar.example.xml
@@ -69,13 +69,13 @@
             aria-expanded="false"
             data-bs-display="static"
           >
-            <span class="bs-toggler-light">
+            <span class="d-light">
               <i class="bi bi-brightness-high-fill"/>
             </span>
-            <span class="bs-toggler-dark">
+            <span class="d-dark">
               <i class="bi bi-moon-stars-fill"/>
             </span>
-            <span class="bs-toggler-auto">
+            <span class="d-auto">
               <i class="bi bi-circle-half"/>
             </span>
             <span class="d-lg-none ms-2">Toggle color mode</span>


### PR DESCRIPTION
**Cosmo** theme is currently missing from `header.xml` and therefore not in the sample theme selector on the website. Adding that one here.

The light navbar sample (`hdr.navbar.example.xml`) currently shows all icons simultaneously. Changing to `d-light`, etc... fixes this.