### PR TITLE
Switch to parml

### DIFF
--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -313,10 +313,31 @@
     <xsl:variable name="is-first-dd" select="empty(preceding-sibling::*[contains(@class, ' topic/dd ')])"/>
     <xsl:choose>
       <xsl:when test="not($is-first-dd)">
-        <xsl:text>col-lg-12  </xsl:text>
+        <xsl:text>col-lg-12 </xsl:text>
       </xsl:when>
       <xsl:when test="$terms=1">
-        <xsl:text>col-lg-9 </xsl:text>
+        <xsl:variable name="term" select="preceding-sibling::*[contains(@class, ' topic/dt ')][1]"/>
+        <xsl:choose>
+          <xsl:when test="$term/@outputclass='col-lg-6'">
+            <xsl:text>col-lg-6</xsl:text>
+          </xsl:when>
+          <xsl:when test="$term/@outputclass='col-lg-5'">
+            <xsl:text>col-lg-7</xsl:text>
+          </xsl:when>
+          <xsl:when test="$term/@outputclass='col-lg-4'">
+            <xsl:text>col-lg-8</xsl:text>
+          </xsl:when>
+          <xsl:when test="$term/@outputclass='col-lg-2'">
+            <xsl:text>col-lg-10</xsl:text>
+          </xsl:when>
+          <xsl:when test="$term/@outputclass='col-lg-1'">
+            <xsl:text>col-lg-11</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>col-lg-9</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text> </xsl:text>
       </xsl:when>
       <xsl:when test="$terms=2">
         <xsl:text>col-lg-6 </xsl:text>

--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -301,6 +301,9 @@
     <xsl:if test="@scalefit='yes'">
       <xsl:text> img-fluid</xsl:text>
     </xsl:if>
+    <xsl:if test="ancestor::*[contains(@class, ' topic/dt ')]">
+      <xsl:call-template name="bootstrap-dt-word-wrap"/>
+    </xsl:if>
     <xsl:text> </xsl:text>
   </xsl:template>
 
@@ -342,6 +345,21 @@
       </xsl:when>
       <xsl:when test="$terms=4">
         <xsl:text>col-lg-2 </xsl:text>
+      </xsl:when>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- Add additional Bootstrap CSS classes to software elements -->
+  <xsl:template name="bootstrap-dt-word-wrap">
+    <xsl:choose>
+      <xsl:when test="contains(@class,' pr-d/')">
+        <xsl:text> text-wrap</xsl:text>
+      </xsl:when>
+      <xsl:when test="contains(@class,' sw-d/')">
+        <xsl:text> text-wrap</xsl:text>
+      </xsl:when>
+      <xsl:when test="contains(@class,' xml-d/')">
+        <xsl:text> text-wrap</xsl:text>
       </xsl:when>
     </xsl:choose>
   </xsl:template>

--- a/Customization/xsl/utility-classes.xsl
+++ b/Customization/xsl/utility-classes.xsl
@@ -316,25 +316,26 @@
         <xsl:text>col-lg-12 </xsl:text>
       </xsl:when>
       <xsl:when test="$terms=1">
-        <xsl:variable name="term" select="preceding-sibling::*[contains(@class, ' topic/dt ')][1]"/>
+        <xsl:variable name="dl" select="../../."/>
+        <xsl:text>col-lg-</xsl:text>
         <xsl:choose>
-          <xsl:when test="$term/@outputclass='col-lg-6'">
-            <xsl:text>col-lg-6</xsl:text>
+          <xsl:when test="contains($dl/@otherprops, 'cols(6)')">
+            <xsl:text>6</xsl:text>
           </xsl:when>
-          <xsl:when test="$term/@outputclass='col-lg-5'">
-            <xsl:text>col-lg-7</xsl:text>
+          <xsl:when test="contains($dl/@otherprops, 'cols(5)')">
+            <xsl:text>7</xsl:text>
           </xsl:when>
-          <xsl:when test="$term/@outputclass='col-lg-4'">
-            <xsl:text>col-lg-8</xsl:text>
+          <xsl:when test="contains($dl/@otherprops, 'cols(4)')">
+            <xsl:text>8</xsl:text>
           </xsl:when>
-          <xsl:when test="$term/@outputclass='col-lg-2'">
-            <xsl:text>col-lg-10</xsl:text>
+          <xsl:when test="contains($dl/@otherprops, 'cols(2)')">
+            <xsl:text>10</xsl:text>
           </xsl:when>
-          <xsl:when test="$term/@outputclass='col-lg-1'">
-            <xsl:text>col-lg-11</xsl:text>
+          <xsl:when test="contains($dl/@otherprops, 'cols(1)')">
+            <xsl:text>11</xsl:text>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:text>col-lg-9</xsl:text>
+            <xsl:text>9</xsl:text>
           </xsl:otherwise>
         </xsl:choose>
         <xsl:text> </xsl:text>
@@ -356,7 +357,29 @@
     <xsl:variable name="terms" select="count(../*[contains(@class, ' topic/dt ')])"/>
     <xsl:choose>
       <xsl:when test="$terms=1">
-        <xsl:text>col-lg-3 </xsl:text>
+        <xsl:variable name="dl" select="../../."/>
+        <xsl:text>col-lg-</xsl:text>
+        <xsl:choose>
+          <xsl:when test="contains($dl/@otherprops, 'cols(6)')">
+            <xsl:text>6</xsl:text>
+          </xsl:when>
+          <xsl:when test="contains($dl/@otherprops, 'cols(5)')">
+            <xsl:text>5</xsl:text>
+          </xsl:when>
+          <xsl:when test="contains($dl/@otherprops, 'cols(4)')">
+            <xsl:text>4</xsl:text>
+          </xsl:when>
+          <xsl:when test="contains($dl/@otherprops, 'cols(2)')">
+            <xsl:text>2</xsl:text>
+          </xsl:when>
+          <xsl:when test="contains($dl/@otherprops, 'cols(1)')">
+            <xsl:text>1</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:text>3</xsl:text>
+          </xsl:otherwise>
+        </xsl:choose>
+        <xsl:text> </xsl:text>
       </xsl:when>
       <xsl:when test="$terms=2">
         <xsl:text>col-lg-3 </xsl:text>

--- a/README.md
+++ b/README.md
@@ -162,31 +162,31 @@ dita --input=path/to/your.ditamap \
 
 The HTML output for the following DITA elements can be annotated with common Bootstrap utility classes for borders, background, text, spacing, etc. using additional command line parameters:
 
-- `bootstrap.css.accessibility.link` – common Bootstrap utility classes for accessibility links
-- `bootstrap.css.accessibility.nav` – common Bootstrap utility classes for accessibility navigation
-- `bootstrap.css.accordion` – common utility classes for Bootstrap accordion components
-- `bootstrap.css.card` – common utility classes for Bootstrap card components
-- `bootstrap.css.carousel` – common utility classes for Bootstrap carousel components
-- `bootstrap.css.carousel.caption` – common utility classes for Bootstrap carousel captions
-- `bootstrap.css.carousel.indicators` – common utility classes for Bootstrap carousel indicators
-- `bootstrap.css.codeblock` – common Bootstrap utility classes for DITA `<codeblock>` elements
-- `bootstrap.css.container.size` - defines Bootstrap container class for main layout and menubar-TOC. Options: `container`, `container-fluid`, `container-sm`, `container-md`, `container-lg`, `container-xl`, `container-xxl` (default)
-- `bootstrap.css.dd` – common utility classes for DITA `<dd>` elements
-- `bootstrap.css.dl` – common utility classes for DITA `<dl>` elements
-- `bootstrap.css.dt` – common utility classes for DITA `<dt>` elements
-- `bootstrap.css.figure` – common utility classes for DITA `<fig>` elements
-- `bootstrap.css.figure.caption` – common utility classes for DITA figure titles
-- `bootstrap.css.figure.image` – common utility classes for images within DITA`<fig>` elements
-- `bootstrap.css.footer` – common utility classes for the HTML `<footer>` element
-- `bootstrap.css.nav.parent` – common utility classes for ancestors of active nav-pill elements
-- `bootstrap.css.pagination` – common utility classes for Bootstrap pagination components
-- `bootstrap.css.section.title` – common Bootstrap utility classes for DITA `<section>` titles
-- `bootstrap.css.shortdesc` – common Bootstrap utility classes for DITA`<shortdesc>` elements
-- `bootstrap.css.table` – common utility classes for DITA `<table>` elements
-- `bootstrap.css.tabs` – common utility classes for Bootstrap horizontal tab components
-- `bootstrap.css.tabs.vertical` – common utility classes for Bootstrap vertical tabs
-- `bootstrap.css.thead` – common utility classes for DITA `<thead>` elements
-- `bootstrap.css.topic.title` – common Bootstrap utility classes for DITA `<topic>` titles
+- `bootstrap.css.accessibility.link` – Common Bootstrap utility classes for accessibility links
+- `bootstrap.css.accessibility.nav` – Common Bootstrap utility classes for accessibility navigation
+- `bootstrap.css.accordion` – Common utility classes for Bootstrap accordion components
+- `bootstrap.css.card` – Common utility classes for Bootstrap card components
+- `bootstrap.css.carousel` – Common utility classes for Bootstrap carousel components
+- `bootstrap.css.carousel.caption` – Common utility classes for Bootstrap carousel captions
+- `bootstrap.css.carousel.indicators` – Common utility classes for Bootstrap carousel indicators
+- `bootstrap.css.codeblock` – Common Bootstrap utility classes for DITA `<codeblock>` elements
+- `bootstrap.css.container.size` – Bootstrap container class for main layout and menubar-TOC. Options: `container`, `container-fluid`, `container-sm`, `container-md`, `container-lg`, `container-xl`, `container-xxl` (default)
+- `bootstrap.css.dd` – Common utility classes for DITA `<dd>` elements
+- `bootstrap.css.dl` – Common utility classes for DITA `<dl>` elements
+- `bootstrap.css.dt` – Common utility classes for DITA `<dt>` elements
+- `bootstrap.css.figure` – Common utility classes for DITA `<fig>` elements
+- `bootstrap.css.figure.caption` – Common utility classes for DITA figure titles
+- `bootstrap.css.figure.image` – Common utility classes for images within DITA`<fig>` elements
+- `bootstrap.css.footer` – Common utility classes for the HTML `<footer>` element
+- `bootstrap.css.nav.parent` – Common utility classes for ancestors of active nav-pill elements
+- `bootstrap.css.pagination` – Common utility classes for Bootstrap pagination components
+- `bootstrap.css.section.title` – Common Bootstrap utility classes for DITA `<section>` titles
+- `bootstrap.css.shortdesc` – Common Bootstrap utility classes for DITA`<shortdesc>` elements
+- `bootstrap.css.table` – Common utility classes for DITA `<table>` elements
+- `bootstrap.css.tabs` – Common utility classes for Bootstrap horizontal tab components
+- `bootstrap.css.tabs.vertical` – Common utility classes for Bootstrap vertical tabs
+- `bootstrap.css.thead` – Common utility classes for DITA `<thead>` elements
+- `bootstrap.css.topic.title` – Common Bootstrap utility classes for DITA `<topic>` titles
 
 You can add your own XSLT customizations by creating a new plug-in that extends the DITA Bootstrap XSLT transforms. Just amend `args.xsl` to point to your own XSLT files. An [XSLT template][16] is included within this repository.
 
@@ -194,34 +194,34 @@ You can add your own XSLT customizations by creating a new plug-in that extends 
 
 The default Bootstrap icons used for DITA `<note>` elements can be overridden using additional command line parameters:
 
-- `bootstrap.icon.note` – icon for standard notes
-- `bootstrap.icon.attention` – icon for attention notes
-- `bootstrap.icon.caution` – icon for caution notes
-- `bootstrap.icon.danger` – icon for danger notes
-- `bootstrap.icon.fastpath` – icon for fastpath notes
-- `bootstrap.icon.important` – icon for important notes
-- `bootstrap.icon.notice` – icon for notice notes
-- `bootstrap.icon.remember` – icon for remember notes
-- `bootstrap.icon.restriction` – icon for restriction notes
-- `bootstrap.icon.tip` – icon for tips
-- `bootstrap.icon.trouble` – icon for trouble notes
-- `bootstrap.icon.warning` – icon for warning notes
+- `bootstrap.icon.note` – Icon for standard notes
+- `bootstrap.icon.attention` – Icon for attention notes
+- `bootstrap.icon.caution` – Icon for caution notes
+- `bootstrap.icon.danger` – Icon for danger notes
+- `bootstrap.icon.fastpath` – Icon for fastpath notes
+- `bootstrap.icon.important` – Icon for important notes
+- `bootstrap.icon.notice` – Icon for notice notes
+- `bootstrap.icon.remember` – Icon for remember notes
+- `bootstrap.icon.restriction` – Icon for restriction notes
+- `bootstrap.icon.tip` – Icon for tips
+- `bootstrap.icon.trouble` – Icon for trouble notes
+- `bootstrap.icon.warning` – Icon for warning notes
 
 ### Optional elements
 
 Bootstrap icons, popovers, tooltips and the dark-mode toggler are enabled by default, but for performance reasons they can be disabled by setting the following command line parameters to `no`:
 
-- `icons.include` – enable Bootstrap icons
-- `popovers.include` – enable Bootstrap popover components and tooltip components
-- `dark.mode.include` - whether to include support for a [dark mode][14] toggler
+- `icons.include` – Enable Bootstrap icons
+- `popovers.include` – Enable Bootstrap popover components and tooltip components
+- `dark.mode.include` – Whether to include support for a [dark mode][14] toggler
 
 Additionally, opt-in breadcrumbs and menu bars and other modifiers can be added using the following parameters
 
-- `args.breadcrumbs` – add Bootstrap breadcrumb components
-- `menubar-toc.include` – add a Bootstrap menubar
-- `scrollspy-toc` – add a Bootstrap [scrollspy][17] navigator
-- `bidi.include` – whether to force included support for RTL languages
-- `toc-spacer.padding` – specifies the vertical padding to add to the side menu
+- `args.breadcrumbs` – Add Bootstrap breadcrumb components
+- `menubar-toc.include` – Add a Bootstrap menubar
+- `scrollspy-toc` – Add a Bootstrap [scrollspy][17] navigator
+- `bidi.include` – Whether to force included support for RTL languages
+- `toc-spacer.padding` – Vertical padding to add to the side menu
 
 ## Feedback
 

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -997,7 +997,8 @@
           </pd>
         </plentry>
       </parml>
-      <p>Opt-in breadcrumbs and menu bars and other modifiers can be added using the following parameters:</p>
+      <p>Opt-in breadcrumbs and menu bars and other modifiers can be enabled by
+      setting the following command line parameters to <option>yes</option>:</p>
       <parml otherprops="cols(4)">
         <plentry>
           <pt>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -617,7 +617,7 @@
             <parmname>--bootstrap.css&#8203;.accessibility&#8203;.link</parmname>
           </pt>
           <pd>
-            common Bootstrap utility classes for accessibility links
+            Common Bootstrap utility classes for accessibility links
           </pd>
         </plentry>
         <plentry>
@@ -625,7 +625,7 @@
             <parmname>--bootstrap.css&#8203;.accessibility&#8203;.nav</parmname>
           </pt>
           <pd>
-            common Bootstrap utility classes for accessibility navigation
+            Common Bootstrap utility classes for accessibility navigation
           </pd>
         </plentry>
         <plentry>
@@ -633,7 +633,7 @@
             <parmname>--bootstrap.css&#8203;.accordion</parmname>
           </pt>
           <pd>
-            common utility classes for Bootstrap
+            Common utility classes for Bootstrap
             <xref href="./accordion.dita" format="dita">accordion components</xref>
           </pd>
         </plentry>
@@ -642,7 +642,7 @@
             <parmname>--bootstrap.css&#8203;.card</parmname>
           </pt>
           <pd>
-            common utility classes for Bootstrap
+            Common utility classes for Bootstrap
             <xref href="./card.dita" format="dita">card components</xref>
           </pd>
         </plentry>
@@ -651,7 +651,7 @@
             <parmname>--bootstrap.css&#8203;.carousel</parmname>
           </pt>
           <pd>
-            common utility classes for Bootstrap
+            Common utility classes for Bootstrap
             <xref href="./carousel.dita" format="dita">carousel components</xref>
           </pd>
         </plentry>
@@ -660,7 +660,7 @@
             <parmname>--bootstrap.css&#8203;.carousel&#8203;.caption</parmname>
           </pt>
           <pd>
-            common utility classes for Bootstrap
+            Common utility classes for Bootstrap
             <xref href="./carousel.dita" format="dita">carousel captions</xref>
           </pd>
         </plentry>
@@ -669,7 +669,7 @@
             <parmname>--bootstrap.css&#8203;.carousel&#8203;.indicators</parmname>
           </pt>
           <pd>
-            common utility classes for Bootstrap
+            Common utility classes for Bootstrap
             <xref href="./carousel.dita" format="dita">carousel indicators</xref>
           </pd>
         </plentry>
@@ -678,7 +678,7 @@
             <parmname>--bootstrap.css&#8203;.codeblock</parmname>
           </pt>
           <pd>
-            common Bootstrap utility classes for DITA
+            Common Bootstrap utility classes for DITA
             <xmlelement>codeblock</xmlelement> elements
           </pd>
         </plentry>
@@ -687,7 +687,7 @@
             <parmname>--bootstrap.css&#8203;.container&#8203;.size</parmname>
           </pt>
           <pd>
-            defines Bootstrap <xref
+            Bootstrap <xref
               href="./containers.dita"
               format="dita"
             >container class</xref> for main layout and menubar-TOC
@@ -697,7 +697,7 @@
           <pt>
             <parmname>--bootstrap.css&#8203;.dd</parmname>
           </pt>
-          <pd>common Bootstrap utility classes for DITA
+          <pd>Common Bootstrap utility classes for DITA
             <xmlelement>dd</xmlelement> definition description elements
           </pd>
         </plentry>
@@ -705,7 +705,7 @@
           <pt>
             <parmname>--bootstrap.css&#8203;.dl</parmname>
           </pt>
-          <pd>common Bootstrap utility classes for DITA
+          <pd>Common Bootstrap utility classes for DITA
             <xmlelement>dl</xmlelement> definition list elements
           </pd>
         </plentry>
@@ -713,7 +713,7 @@
           <pt>
             <parmname>--bootstrap.css&#8203;.dt</parmname>
           </pt>
-          <pd>common Bootstrap utility classes for DITA
+          <pd>Common Bootstrap utility classes for DITA
             <xmlelement>dt</xmlelement> definition term elements
           </pd>
         </plentry>
@@ -721,7 +721,7 @@
           <pt>
             <parmname>--bootstrap.css&#8203;.figure</parmname>
           </pt>
-          <pd>common Bootstrap utility classes for DITA
+          <pd>Common Bootstrap utility classes for DITA
             <xmlelement>fig</xmlelement> elements
           </pd>
         </plentry>
@@ -730,7 +730,7 @@
             <parmname>--bootstrap.css&#8203;.figure&#8203;.caption</parmname>
           </pt>
           <pd>
-            common Bootstrap utility classes for DITA
+            Common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements within <xmlelement>fig</xmlelement> elements
           </pd>
         </plentry>
@@ -739,7 +739,7 @@
             <parmname>--bootstrap.css&#8203;.figure&#8203;.image</parmname>
           </pt>
           <pd>
-            common Bootstrap utility classes for DITA
+            Common Bootstrap utility classes for DITA
             <xmlelement>image</xmlelement> elements within <xmlelement>fig</xmlelement> elements
           </pd>
         </plentry>
@@ -748,7 +748,7 @@
             <parmname>--bootstrap.css&#8203;.footer</parmname>
           </pt>
           <pd>
-            common utility classes for the HTML
+            Common utility classes for the HTML
             <xmlelement>footer</xmlelement> element
           </pd>
         </plentry>
@@ -757,7 +757,7 @@
             <parmname>--bootstrap.css&#8203;.nav&#8203;.parent</parmname>
           </pt>
           <pd>
-            common Bootstrap utility classes for ancestors of active nav-pill elements
+            Common Bootstrap utility classes for ancestors of active nav-pill elements
           </pd>
         </plentry>
         <plentry>
@@ -765,7 +765,7 @@
             <parmname>--bootstrap.css&#8203;.pagination</parmname>
           </pt>
           <pd>
-            common utility classes for Bootstrap
+            Common utility classes for Bootstrap
             <xref href="./pagination.dita" format="dita">pagination components</xref>
           </pd>
         </plentry>
@@ -774,7 +774,7 @@
             <parmname>--bootstrap.css&#8203;.section&#8203;.title</parmname>
           </pt>
           <pd>
-            common Bootstrap utility classes for DITA
+            Common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements within <xmlelement>section</xmlelement> elements
           </pd>
         </plentry>
@@ -783,7 +783,7 @@
             <parmname>--bootstrap.css&#8203;.shortdesc</parmname>
           </pt>
           <pd>
-            common Bootstrap utility classes for DITA
+            Common Bootstrap utility classes for DITA
             <xmlelement>shortdesc</xmlelement> elements
           </pd>
         </plentry>
@@ -792,7 +792,7 @@
             <parmname>--bootstrap.css&#8203;.table</parmname>
           </pt>
           <pd>
-            common Bootstrap utility classes for DITA
+            Common Bootstrap utility classes for DITA
             <xmlelement>table</xmlelement> elements
           </pd>
         </plentry>
@@ -801,7 +801,7 @@
             <parmname>--bootstrap.css&#8203;.tabs</parmname>
           </pt>
           <pd>
-            common utility classes for Bootstrap
+            Common utility classes for Bootstrap
             <xref href="./tabs.dita" format="dita">tabbed dialog components</xref>
           </pd>
         </plentry>
@@ -810,7 +810,7 @@
             <parmname>--bootstrap.css&#8203;.tabs&#8203;.vertical</parmname>
           </pt>
           <pd>
-            common utility classes for Bootstrap
+            Common utility classes for Bootstrap
             <xref href="./tabs.dita" format="dita">vertical tabbed dialog components</xref>
           </pd>
         </plentry>
@@ -818,7 +818,7 @@
           <pt>
             <parmname>--bootstrap.css&#8203;.thead</parmname>
           </pt>
-          <pd>common Bootstrap utility classes for DITA
+          <pd>Common Bootstrap utility classes for DITA
             <xmlelement>thead</xmlelement> elements
           </pd>
         </plentry>
@@ -827,7 +827,7 @@
             <parmname>--bootstrap.css&#8203;.topic&#8203;.title</parmname>
           </pt>
           <pd>
-            common Bootstrap utility classes for DITA
+            Common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements within <xmlelement>topic</xmlelement> elements
           </pd>
         </plentry>
@@ -855,7 +855,7 @@
             <parmname>--bootstrap.icon&#8203;.note</parmname>
           </pt>
           <pd>
-            icon for standard notes
+            Icon for standard notes
           </pd>
         </plentry>
         <plentry>
@@ -863,7 +863,7 @@
             <parmname>--bootstrap.icon&#8203;.attention</parmname>
           </pt>
           <pd>
-            icon for attention notes
+            Icon for attention notes
           </pd>
         </plentry>
         <plentry>
@@ -871,7 +871,7 @@
             <parmname>--bootstrap.icon&#8203;.caution</parmname>
           </pt>
           <pd>
-            icon for caution notes
+            Icon for caution notes
           </pd>
         </plentry>
         <plentry>
@@ -879,7 +879,7 @@
             <parmname>--bootstrap.icon&#8203;.danger</parmname>
           </pt>
           <pd>
-            icon for danger notes
+            Icon for danger notes
           </pd>
         </plentry>
         <plentry>
@@ -887,7 +887,7 @@
             <parmname>--bootstrap.icon&#8203;.fastpath</parmname>
           </pt>
           <pd>
-            icon for fastpath notes
+            Icon for fastpath notes
           </pd>
         </plentry>
         <plentry>
@@ -895,7 +895,7 @@
             <parmname>--bootstrap.icon&#8203;.important</parmname>
           </pt>
           <pd>
-            icon for important notes
+            Icon for important notes
           </pd>
         </plentry>
         <plentry>
@@ -903,7 +903,7 @@
             <parmname>--bootstrap.icon&#8203;.notice</parmname>
           </pt>
           <pd>
-            icon for notice notes
+            Icon for notice notes
           </pd>
         </plentry>
         <plentry>
@@ -911,7 +911,7 @@
             <parmname>--bootstrap.icon&#8203;.remember</parmname>
           </pt>
           <pd>
-            icon for remember notes
+            Icon for remember notes
           </pd>
         </plentry>
         <plentry>
@@ -919,7 +919,7 @@
             <parmname>--bootstrap.icon&#8203;.restriction</parmname>
           </pt>
           <pd>
-            icon for restriction notes
+            Icon for restriction notes
           </pd>
         </plentry>
         <plentry>
@@ -927,7 +927,7 @@
             <parmname>--bootstrap.icon&#8203;.tip</parmname>
           </pt>
           <pd>
-            icon for tips
+            Icon for tips
           </pd>
         </plentry>
         <plentry>
@@ -935,7 +935,7 @@
             <parmname>--bootstrap.icon&#8203;.trouble</parmname>
           </pt>
           <pd>
-            icon for trouble notes
+            Icon for trouble notes
           </pd>
         </plentry>
         <plentry>
@@ -943,7 +943,7 @@
             <parmname>--bootstrap.icon&#8203;.warning</parmname>
           </pt>
           <pd>
-            icon for warning notes
+            Icon for warning notes
           </pd>
         </plentry>
       </parml>
@@ -969,7 +969,7 @@
           <pt>
             <parmname>--icons.include</parmname>
           </pt>
-          <pd>enable Bootstrap
+          <pd>Enable Bootstrap
             <xref href="./icons.dita" format="dita">icons</xref>
           </pd>
         </plentry>
@@ -978,7 +978,7 @@
             <parmname>--popovers.include</parmname>
           </pt>
           <pd>
-            enable Bootstrap
+            Enable Bootstrap
             <xref href="./popovers.dita" format="dita">popover components</xref> and
             <xref href="./tooltips.dita" format="dita">tooltip components</xref>
           </pd>
@@ -988,7 +988,7 @@
             <parmname>--dark.mode.include</parmname>
           </pt>
           <pd>
-            whether to include support for a
+            Whether to include support for a
             <xref
               href="https://getbootstrap.com/docs/5.3/customize/color-modes/#dark-mode"
               format="html"
@@ -1004,7 +1004,7 @@
           <pt>
             <parmname>--args.breadcrumbs</parmname>
           </pt>
-          <pd>enable Bootstrap
+          <pd>Enable Bootstrap
           <xref href="./breadcrumb.dita" format="dita">breadcrumb components</xref>
         </pd>
         </plentry>
@@ -1013,7 +1013,7 @@
             <parmname>--menubar-toc.include</parmname>
           </pt>
           <pd>
-            add a Bootstrap menubar
+            Add a Bootstrap menubar
           </pd>
         </plentry>
         <plentry>
@@ -1021,7 +1021,7 @@
             <parmname>--bidi.include</parmname>
           </pt>
           <pd>
-            whether to force included support for
+            Whether to force included support for
             <xref href="./rtl.dita" format="dita">RTL languages</xref>
           </pd>
         </plentry>
@@ -1034,7 +1034,7 @@
             <parmname>--scrollspy-toc</parmname>
           </pt>
           <pd>
-            add a Bootstrap <xref href="./scrollspy.dita" format="dita">scrollspy</xref> navigator
+            Add a Bootstrap <xref href="./scrollspy.dita" format="dita">scrollspy</xref> navigator
           </pd>
         </plentry>
         <plentry>
@@ -1042,7 +1042,7 @@
             <parmname>--toc-spacer.padding</parmname>
           </pt>
           <pd>
-            specifies the vertical padding to add to the side menu
+            Vertical padding to add to the side menu
           </pd>
         </plentry>
       </parml>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -542,23 +542,28 @@
           scope="external"
         >collapsible</xref> menus. The following new options are available:
       </p>
-      <ul>
-        <li>
-          <option>nav-pill-full</option> – Styled full ToC using nav-pills
-        </li>
-        <li>
-          <option>nav-pill-partial</option> – Styled partial ToC using nav-pills
-        </li>
-        <li>
-          <option>list-group-full</option> – Styled full ToC within a list group
-        </li>
-        <li>
-          <option>list-group-partial</option> – Styled partial ToC within a list group
-        </li>
-        <li>
-          <option>collapsible</option> - tyled full ToC with collapsible elements
-        </li>
-      </ul>
+      <parml>
+        <plentry>
+          <pt><option>nav-pill-full</option></pt>
+          <pd>Styled full ToC using nav-pills</pd>
+        </plentry>
+        <plentry>
+          <pt><option>nav-pill-partial</option></pt>
+          <pd>Styled partial ToC using nav-pills</pd>
+        </plentry>
+        <plentry>
+          <pt><option>list-group-full</option></pt>
+          <pd>Styled full ToC within a list group</pd>
+        </plentry>
+        <plentry>
+          <pt><option>list-group-partial</option></pt>
+          <pd>Styled partial ToC within a list group</pd>
+        </plentry>
+        <plentry>
+          <pt><option>collapsible</option></pt>
+          <pd>Styled full ToC with collapsible elements</pd>
+        </plentry>
+      </parml>
       <codeblock outputclass="language-bash"><cmdname>dita</cmdname> <parmname>--input</parmname>=<filepath
         >path/to/your.ditamap</filepath> \
      <parmname>--format</parmname>=<option>html5-bootstrap</option> \
@@ -606,111 +611,227 @@
         <xref href="https://getbootstrap.com/docs/5.3/utilities/text" format="html" scope="external">text</xref>,
         <xref href="https://getbootstrap.com/docs/5.3/utilities/spacing" format="html" scope="external">spacing</xref>,
         etc. using additional command line parameters:</p>
-      <ul>
-        <li>
-          <parmname>--bootstrap.css.accessibility.link</parmname> – common Bootstrap utility classes for accessibility
-          links
-        </li>
-        <li>
-          <parmname>--bootstrap.css.accessibility.nav</parmname> – common Bootstrap utility classes for accessibility
-          navigation
-        </li>
-        <li>
-          <parmname>--bootstrap.css.accordion</parmname> – common utility classes for Bootstrap
-          <xref href="./accordion.dita" format="dita">accordion components</xref>
-        </li>
-        <li>
-          <parmname>--bootstrap.css.card</parmname> – common utility classes for Bootstrap
-          <xref href="./card.dita" format="dita">card components</xref>
-        </li>
-        <li>
-          <parmname>--bootstrap.css.carousel</parmname> – common utility classes for Bootstrap
-          <xref href="./carousel.dita" format="dita">carousel components</xref>
-        </li>
-        <li>
-          <parmname>--bootstrap.css.carousel.caption</parmname> – common utility classes for Bootstrap
-          <xref href="./carousel.dita" format="dita">carousel captions</xref>
-        </li>
-        <li>
-          <parmname>--bootstrap.css.carousel.indicators</parmname> – common utility classes for Bootstrap
-          <xref href="./carousel.dita" format="dita">carousel indicators</xref>
-        </li>
-        <li>
-          <parmname>--bootstrap.css.codeblock</parmname> – common Bootstrap utility classes for DITA
+      <parml>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.accessibility&#8203;.link</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common Bootstrap utility classes for accessibility links
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.accessibility&#8203;.nav</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common Bootstrap utility classes for accessibility navigation
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.accordion</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common utility classes for Bootstrap
+            <xref href="./accordion.dita" format="dita">accordion components</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.card</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common utility classes for Bootstrap
+            <xref href="./card.dita" format="dita">card components</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.carousel</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common utility classes for Bootstrap
+            <xref href="./carousel.dita" format="dita">carousel components</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.carousel&#8203;.caption</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common utility classes for Bootstrap
+            <xref href="./carousel.dita" format="dita">carousel captions</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.carousel&#8203;.indicators</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common utility classes for Bootstrap
+            <xref href="./carousel.dita" format="dita">carousel indicators</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.codeblock</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common Bootstrap utility classes for DITA
             <xmlelement>codeblock</xmlelement> elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.container.size</parmname> – defines the Bootstrap <xref
-            href="./containers.dita"
-            format="dita"
-          >container class</xref> for main layout and
-           menubar-TOC.
-        </li>
-        <li>
-          <parmname>--bootstrap.css.dd</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.container&#8203;.size</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            defines Bootstrap <xref
+              href="./containers.dita"
+              format="dita"
+            >container class</xref> for main layout and menubar-TOC
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.dd</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
             <xmlelement>dd</xmlelement> definition description elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.dl</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.dl</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
             <xmlelement>dl</xmlelement> definition list elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.dt</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.dt</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
             <xmlelement>dt</xmlelement> definition term elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.figure</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.figure</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
             <xmlelement>fig</xmlelement> elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.figure.caption</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.figure&#8203;.caption</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements within <xmlelement>fig</xmlelement> elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.figure.image</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.figure&#8203;.image</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common Bootstrap utility classes for DITA
             <xmlelement>image</xmlelement> elements within <xmlelement>fig</xmlelement> elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.footer</parmname> – common utility classes for the HTML
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.footer</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common utility classes for the HTML
             <xmlelement>footer</xmlelement> element
-        </li>
-        <li>
-          <parmname>--bootstrap.css.nav.parent</parmname> – common Bootstrap utility classes for ancestors of active
-          nav-pill elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.pagination</parmname> – common utility classes for Bootstrap
-          <xref href="./pagination.dita" format="dita">pagination components</xref>
-        </li>
-        <li>
-          <parmname>--bootstrap.css.section.title</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.nav&#8203;.parent</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common Bootstrap utility classes for ancestors of active nav-pill elements
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.pagination</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common utility classes for Bootstrap
+            <xref href="./pagination.dita" format="dita">pagination components</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.section&#8203;.title</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements within <xmlelement>section</xmlelement> elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.shortdesc</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.shortdesc</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common Bootstrap utility classes for DITA
             <xmlelement>shortdesc</xmlelement> elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.table</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.table</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common Bootstrap utility classes for DITA
             <xmlelement>table</xmlelement> elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.tabs</parmname> – common utility classes for Bootstrap
-          <xref href="./tabs.dita" format="dita">tabbed dialog components</xref>
-        </li>
-        <li>
-          <parmname>--bootstrap.css.tabs.vertical</parmname> – common utility classes for Bootstrap
-          <xref href="./tabs.dita" format="dita">vertical tabbed dialog components</xref>
-        </li>
-        <li>
-          <parmname>--bootstrap.css.thead</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.tabs</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common utility classes for Bootstrap
+            <xref href="./tabs.dita" format="dita">tabbed dialog components</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.tabs&#8203;.vertical</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common utility classes for Bootstrap
+            <xref href="./tabs.dita" format="dita">vertical tabbed dialog components</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.thead</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
             <xmlelement>thead</xmlelement> elements
-        </li>
-        <li>
-          <parmname>--bootstrap.css.topic.title</parmname> – common Bootstrap utility classes for DITA
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.topic&#8203;.title</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements within <xmlelement>topic</xmlelement> elements
-        </li>
-      </ul>
+          </pd>
+        </plentry>
+      </parml>
     </section>
     <section>
       <title>Bootstrap icons for DITA notes</title>
@@ -728,44 +849,104 @@
       <indexterm><parmname>--bootstrap.icon.warning</parmname></indexterm>
       <p>The default Bootstrap icons used for DITA <xmlelement
         >note</xmlelement> elements can be overridden using additional command line parameters:</p>
-      <ul>
-        <li>
-          <parmname>--bootstrap.icon.note</parmname> – icon for standard notes
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.attention</parmname> – icon for attention notes
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.caution</parmname> – icon for caution notes
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.danger</parmname> – icon for danger notes
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.fastpath</parmname> – icon for fastpath notes
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.important</parmname> – icon for important notes
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.notice</parmname> – icon for notice notes
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.remember</parmname> – icon for remember notes
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.restriction</parmname> – icon for restriction notes
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.tip</parmname> – icon for tips
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.trouble</parmname> – icon for trouble notes
-        </li>
-        <li>
-          <parmname>--bootstrap.icon.warning</parmname> – icon for warning notes
-        </li>
-      </ul>
+      <parml>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.note</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for standard notes
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.attention</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for attention notes
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.caution</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for caution notes
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.danger</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for danger notes
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.fastpath</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for fastpath notes
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.important</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for important notes
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.notice</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for notice notes
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.remember</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for remember notes
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.restriction</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for restriction notes
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.tip</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for tips
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.trouble</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for trouble notes
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.warning</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            icon for warning notes
+          </pd>
+        </plentry>
+      </parml>
     </section>
     <section>
       <title>Optional elements</title>
@@ -783,40 +964,83 @@
           format="dita"
         >dark mode toggler</xref> are enabled by default, but for performance reasons they can be disabled by setting
         the following command line parameters to <option>no</option>:</p>
-      <ul>
-        <li>
-          <parmname>--icons.include</parmname> – enable Bootstrap
-          <xref href="./icons.dita" format="dita">icons</xref></li>
-        <li>
-          <parmname>--popovers.include</parmname> – enable Bootstrap
-          <xref href="./popovers.dita" format="dita">popover components</xref> and
-          <xref href="./tooltips.dita" format="dita">tooltip components</xref></li>
-        <li>
-          <parmname>--dark.mode.include</parmname> – whether to include support for a
-          <xref
-            href="https://getbootstrap.com/docs/5.3/customize/color-modes/#dark-mode"
-            format="html"
-            scope="external"
-          >dark mode</xref> toggler</li>
-      </ul>
+      <parml>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname>--icons.include</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">enable Bootstrap
+            <xref href="./icons.dita" format="dita">icons</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname>--popovers.include</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            enable Bootstrap
+            <xref href="./popovers.dita" format="dita">popover components</xref> and
+            <xref href="./tooltips.dita" format="dita">tooltip components</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname>--dark.mode.include</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            whether to include support for a
+            <xref
+              href="https://getbootstrap.com/docs/5.3/customize/color-modes/#dark-mode"
+              format="html"
+              scope="external"
+            >dark mode</xref> toggler
+          </pd>
+        </plentry>
+      </parml>
       <p>Opt-in breadcrumbs and menu bars and other modifiers can be added using the following parameters:</p>
-      <ul>
-        <li>
-          <parmname>--args.breadcrumbs</parmname> – enable Bootstrap
-          <xref href="./breadcrumb.dita" format="dita">breadcrumb components</xref></li>
-        <li>
-          <parmname>--menubar-toc.include</parmname> – add a Bootstrap menubar</li>
-        <li>
-          <parmname>--scrollspy-toc</parmname> – add a Bootstrap <xref
-            href="./scrollspy.dita"
-            format="dita"
-          >scrollspy</xref> navigator</li>
-        <li>
-          <parmname>--bidi.include</parmname> – whether to force included support for
-          <xref href="./rtl.dita" format="dita">RTL languages</xref></li>
-        <li>
-          <parmname>--toc-spacer.padding</parmname> – specifies the vertical padding to add to the side menu</li>
-      </ul>
+      <parml>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname>--args.breadcrumbs</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">enable Bootstrap
+          <xref href="./breadcrumb.dita" format="dita">breadcrumb components</xref>
+        </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname>--menubar-toc.include</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            add a Bootstrap menubar
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname>--scrollspy-toc</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            add a Bootstrap <xref href="./scrollspy.dita" format="dita">scrollspy</xref> navigator
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname>--bidi.include</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            whether to force included support for
+            <xref href="./rtl.dita" format="dita">RTL languages</xref>
+          </pd>
+        </plentry>
+        <plentry>
+          <pt outputclass="col-lg-4">
+            <parmname>--toc-spacer.padding</parmname>
+          </pt>
+          <pd outputclass="col-lg-8">
+            specifies the vertical padding to add to the side menu
+          </pd>
+        </plentry>
+      </parml>
     </section>
     <section>
       <note

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -616,7 +616,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.accessibility&#8203;.link</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common Bootstrap utility classes for accessibility links
           </pd>
         </plentry>
@@ -624,7 +624,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.accessibility&#8203;.nav</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common Bootstrap utility classes for accessibility navigation
           </pd>
         </plentry>
@@ -632,7 +632,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.accordion</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common utility classes for Bootstrap
             <xref href="./accordion.dita" format="dita">accordion components</xref>
           </pd>
@@ -641,7 +641,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.card</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common utility classes for Bootstrap
             <xref href="./card.dita" format="dita">card components</xref>
           </pd>
@@ -650,7 +650,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.carousel</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common utility classes for Bootstrap
             <xref href="./carousel.dita" format="dita">carousel components</xref>
           </pd>
@@ -659,7 +659,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.carousel&#8203;.caption</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common utility classes for Bootstrap
             <xref href="./carousel.dita" format="dita">carousel captions</xref>
           </pd>
@@ -668,7 +668,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.carousel&#8203;.indicators</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common utility classes for Bootstrap
             <xref href="./carousel.dita" format="dita">carousel indicators</xref>
           </pd>
@@ -677,7 +677,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.codeblock</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common Bootstrap utility classes for DITA
             <xmlelement>codeblock</xmlelement> elements
           </pd>
@@ -686,7 +686,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.container&#8203;.size</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             defines Bootstrap <xref
               href="./containers.dita"
               format="dita"
@@ -697,7 +697,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.dd</parmname>
           </pt>
-          <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
+          <pd>common Bootstrap utility classes for DITA
             <xmlelement>dd</xmlelement> definition description elements
           </pd>
         </plentry>
@@ -705,7 +705,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.dl</parmname>
           </pt>
-          <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
+          <pd>common Bootstrap utility classes for DITA
             <xmlelement>dl</xmlelement> definition list elements
           </pd>
         </plentry>
@@ -713,7 +713,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.dt</parmname>
           </pt>
-          <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
+          <pd>common Bootstrap utility classes for DITA
             <xmlelement>dt</xmlelement> definition term elements
           </pd>
         </plentry>
@@ -721,7 +721,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.figure</parmname>
           </pt>
-          <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
+          <pd>common Bootstrap utility classes for DITA
             <xmlelement>fig</xmlelement> elements
           </pd>
         </plentry>
@@ -729,7 +729,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.figure&#8203;.caption</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements within <xmlelement>fig</xmlelement> elements
           </pd>
@@ -738,7 +738,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.figure&#8203;.image</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common Bootstrap utility classes for DITA
             <xmlelement>image</xmlelement> elements within <xmlelement>fig</xmlelement> elements
           </pd>
@@ -747,7 +747,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.footer</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common utility classes for the HTML
             <xmlelement>footer</xmlelement> element
           </pd>
@@ -756,7 +756,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.nav&#8203;.parent</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common Bootstrap utility classes for ancestors of active nav-pill elements
           </pd>
         </plentry>
@@ -764,7 +764,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.pagination</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common utility classes for Bootstrap
             <xref href="./pagination.dita" format="dita">pagination components</xref>
           </pd>
@@ -773,7 +773,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.section&#8203;.title</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements within <xmlelement>section</xmlelement> elements
           </pd>
@@ -782,7 +782,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.shortdesc</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common Bootstrap utility classes for DITA
             <xmlelement>shortdesc</xmlelement> elements
           </pd>
@@ -791,7 +791,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.table</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common Bootstrap utility classes for DITA
             <xmlelement>table</xmlelement> elements
           </pd>
@@ -800,7 +800,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.tabs</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common utility classes for Bootstrap
             <xref href="./tabs.dita" format="dita">tabbed dialog components</xref>
           </pd>
@@ -809,7 +809,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.tabs&#8203;.vertical</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common utility classes for Bootstrap
             <xref href="./tabs.dita" format="dita">vertical tabbed dialog components</xref>
           </pd>
@@ -818,7 +818,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.thead</parmname>
           </pt>
-          <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
+          <pd>common Bootstrap utility classes for DITA
             <xmlelement>thead</xmlelement> elements
           </pd>
         </plentry>
@@ -826,7 +826,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.css&#8203;.topic&#8203;.title</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             common Bootstrap utility classes for DITA
             <xmlelement>title</xmlelement> elements within <xmlelement>topic</xmlelement> elements
           </pd>
@@ -854,7 +854,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.note</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for standard notes
           </pd>
         </plentry>
@@ -862,7 +862,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.attention</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for attention notes
           </pd>
         </plentry>
@@ -870,7 +870,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.caution</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for caution notes
           </pd>
         </plentry>
@@ -878,7 +878,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.danger</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for danger notes
           </pd>
         </plentry>
@@ -886,7 +886,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.fastpath</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for fastpath notes
           </pd>
         </plentry>
@@ -894,7 +894,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.important</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for important notes
           </pd>
         </plentry>
@@ -902,7 +902,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.notice</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for notice notes
           </pd>
         </plentry>
@@ -910,7 +910,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.remember</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for remember notes
           </pd>
         </plentry>
@@ -918,7 +918,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.restriction</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for restriction notes
           </pd>
         </plentry>
@@ -926,7 +926,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.tip</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for tips
           </pd>
         </plentry>
@@ -934,7 +934,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.trouble</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for trouble notes
           </pd>
         </plentry>
@@ -942,7 +942,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bootstrap.icon&#8203;.warning</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             icon for warning notes
           </pd>
         </plentry>
@@ -969,7 +969,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--icons.include</parmname>
           </pt>
-          <pd outputclass="col-lg-8">enable Bootstrap
+          <pd>enable Bootstrap
             <xref href="./icons.dita" format="dita">icons</xref>
           </pd>
         </plentry>
@@ -977,7 +977,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--popovers.include</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             enable Bootstrap
             <xref href="./popovers.dita" format="dita">popover components</xref> and
             <xref href="./tooltips.dita" format="dita">tooltip components</xref>
@@ -987,7 +987,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--dark.mode.include</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             whether to include support for a
             <xref
               href="https://getbootstrap.com/docs/5.3/customize/color-modes/#dark-mode"
@@ -1003,7 +1003,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--args.breadcrumbs</parmname>
           </pt>
-          <pd outputclass="col-lg-8">enable Bootstrap
+          <pd>enable Bootstrap
           <xref href="./breadcrumb.dita" format="dita">breadcrumb components</xref>
         </pd>
         </plentry>
@@ -1011,7 +1011,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--menubar-toc.include</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             add a Bootstrap menubar
           </pd>
         </plentry>
@@ -1019,7 +1019,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--scrollspy-toc</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             add a Bootstrap <xref href="./scrollspy.dita" format="dita">scrollspy</xref> navigator
           </pd>
         </plentry>
@@ -1027,7 +1027,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--bidi.include</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             whether to force included support for
             <xref href="./rtl.dita" format="dita">RTL languages</xref>
           </pd>
@@ -1036,7 +1036,7 @@
           <pt outputclass="col-lg-4">
             <parmname>--toc-spacer.padding</parmname>
           </pt>
-          <pd outputclass="col-lg-8">
+          <pd>
             specifies the vertical padding to add to the side menu
           </pd>
         </plentry>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -614,7 +614,7 @@
       <parml>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.accessibility&#8203;.link</parmname>
+            <parmname>--bootstrap.css&#8203;.accessibility&#8203;.link</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common Bootstrap utility classes for accessibility links
@@ -622,7 +622,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.accessibility&#8203;.nav</parmname>
+            <parmname>--bootstrap.css&#8203;.accessibility&#8203;.nav</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common Bootstrap utility classes for accessibility navigation
@@ -630,7 +630,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.accordion</parmname>
+            <parmname>--bootstrap.css&#8203;.accordion</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common utility classes for Bootstrap
@@ -639,7 +639,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.card</parmname>
+            <parmname>--bootstrap.css&#8203;.card</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common utility classes for Bootstrap
@@ -648,7 +648,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.carousel</parmname>
+            <parmname>--bootstrap.css&#8203;.carousel</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common utility classes for Bootstrap
@@ -657,7 +657,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.carousel&#8203;.caption</parmname>
+            <parmname>--bootstrap.css&#8203;.carousel&#8203;.caption</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common utility classes for Bootstrap
@@ -666,7 +666,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.carousel&#8203;.indicators</parmname>
+            <parmname>--bootstrap.css&#8203;.carousel&#8203;.indicators</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common utility classes for Bootstrap
@@ -675,7 +675,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.codeblock</parmname>
+            <parmname>--bootstrap.css&#8203;.codeblock</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common Bootstrap utility classes for DITA
@@ -684,7 +684,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.container&#8203;.size</parmname>
+            <parmname>--bootstrap.css&#8203;.container&#8203;.size</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             defines Bootstrap <xref
@@ -695,7 +695,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.dd</parmname>
+            <parmname>--bootstrap.css&#8203;.dd</parmname>
           </pt>
           <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
             <xmlelement>dd</xmlelement> definition description elements
@@ -703,7 +703,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.dl</parmname>
+            <parmname>--bootstrap.css&#8203;.dl</parmname>
           </pt>
           <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
             <xmlelement>dl</xmlelement> definition list elements
@@ -711,7 +711,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.dt</parmname>
+            <parmname>--bootstrap.css&#8203;.dt</parmname>
           </pt>
           <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
             <xmlelement>dt</xmlelement> definition term elements
@@ -719,7 +719,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.figure</parmname>
+            <parmname>--bootstrap.css&#8203;.figure</parmname>
           </pt>
           <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
             <xmlelement>fig</xmlelement> elements
@@ -727,7 +727,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.figure&#8203;.caption</parmname>
+            <parmname>--bootstrap.css&#8203;.figure&#8203;.caption</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common Bootstrap utility classes for DITA
@@ -736,7 +736,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.figure&#8203;.image</parmname>
+            <parmname>--bootstrap.css&#8203;.figure&#8203;.image</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common Bootstrap utility classes for DITA
@@ -745,7 +745,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.footer</parmname>
+            <parmname>--bootstrap.css&#8203;.footer</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common utility classes for the HTML
@@ -754,7 +754,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.nav&#8203;.parent</parmname>
+            <parmname>--bootstrap.css&#8203;.nav&#8203;.parent</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common Bootstrap utility classes for ancestors of active nav-pill elements
@@ -762,7 +762,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.pagination</parmname>
+            <parmname>--bootstrap.css&#8203;.pagination</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common utility classes for Bootstrap
@@ -771,7 +771,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.section&#8203;.title</parmname>
+            <parmname>--bootstrap.css&#8203;.section&#8203;.title</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common Bootstrap utility classes for DITA
@@ -780,7 +780,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.shortdesc</parmname>
+            <parmname>--bootstrap.css&#8203;.shortdesc</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common Bootstrap utility classes for DITA
@@ -789,7 +789,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.table</parmname>
+            <parmname>--bootstrap.css&#8203;.table</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common Bootstrap utility classes for DITA
@@ -798,7 +798,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.tabs</parmname>
+            <parmname>--bootstrap.css&#8203;.tabs</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common utility classes for Bootstrap
@@ -807,7 +807,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.tabs&#8203;.vertical</parmname>
+            <parmname>--bootstrap.css&#8203;.tabs&#8203;.vertical</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common utility classes for Bootstrap
@@ -816,7 +816,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.thead</parmname>
+            <parmname>--bootstrap.css&#8203;.thead</parmname>
           </pt>
           <pd outputclass="col-lg-8">common Bootstrap utility classes for DITA
             <xmlelement>thead</xmlelement> elements
@@ -824,7 +824,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.css&#8203;.topic&#8203;.title</parmname>
+            <parmname>--bootstrap.css&#8203;.topic&#8203;.title</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             common Bootstrap utility classes for DITA
@@ -852,7 +852,7 @@
       <parml>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.note</parmname>
+            <parmname>--bootstrap.icon&#8203;.note</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for standard notes
@@ -860,7 +860,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.attention</parmname>
+            <parmname>--bootstrap.icon&#8203;.attention</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for attention notes
@@ -868,7 +868,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.caution</parmname>
+            <parmname>--bootstrap.icon&#8203;.caution</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for caution notes
@@ -876,7 +876,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.danger</parmname>
+            <parmname>--bootstrap.icon&#8203;.danger</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for danger notes
@@ -884,7 +884,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.fastpath</parmname>
+            <parmname>--bootstrap.icon&#8203;.fastpath</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for fastpath notes
@@ -892,7 +892,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.important</parmname>
+            <parmname>--bootstrap.icon&#8203;.important</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for important notes
@@ -900,7 +900,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.notice</parmname>
+            <parmname>--bootstrap.icon&#8203;.notice</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for notice notes
@@ -908,7 +908,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.remember</parmname>
+            <parmname>--bootstrap.icon&#8203;.remember</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for remember notes
@@ -916,7 +916,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.restriction</parmname>
+            <parmname>--bootstrap.icon&#8203;.restriction</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for restriction notes
@@ -924,7 +924,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.tip</parmname>
+            <parmname>--bootstrap.icon&#8203;.tip</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for tips
@@ -932,7 +932,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.trouble</parmname>
+            <parmname>--bootstrap.icon&#8203;.trouble</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for trouble notes
@@ -940,7 +940,7 @@
         </plentry>
         <plentry>
           <pt outputclass="col-lg-4">
-            <parmname outputclass="text-wrap">--bootstrap.icon&#8203;.warning</parmname>
+            <parmname>--bootstrap.icon&#8203;.warning</parmname>
           </pt>
           <pd outputclass="col-lg-8">
             icon for warning notes

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -611,9 +611,9 @@
         <xref href="https://getbootstrap.com/docs/5.3/utilities/text" format="html" scope="external">text</xref>,
         <xref href="https://getbootstrap.com/docs/5.3/utilities/spacing" format="html" scope="external">spacing</xref>,
         etc. using additional command line parameters:</p>
-      <parml>
+      <parml otherprops="cols(4)">
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.accessibility&#8203;.link</parmname>
           </pt>
           <pd>
@@ -621,7 +621,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.accessibility&#8203;.nav</parmname>
           </pt>
           <pd>
@@ -629,7 +629,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.accordion</parmname>
           </pt>
           <pd>
@@ -638,7 +638,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.card</parmname>
           </pt>
           <pd>
@@ -647,7 +647,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.carousel</parmname>
           </pt>
           <pd>
@@ -656,7 +656,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.carousel&#8203;.caption</parmname>
           </pt>
           <pd>
@@ -665,7 +665,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.carousel&#8203;.indicators</parmname>
           </pt>
           <pd>
@@ -674,7 +674,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.codeblock</parmname>
           </pt>
           <pd>
@@ -683,7 +683,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.container&#8203;.size</parmname>
           </pt>
           <pd>
@@ -694,7 +694,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.dd</parmname>
           </pt>
           <pd>common Bootstrap utility classes for DITA
@@ -702,7 +702,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.dl</parmname>
           </pt>
           <pd>common Bootstrap utility classes for DITA
@@ -710,7 +710,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.dt</parmname>
           </pt>
           <pd>common Bootstrap utility classes for DITA
@@ -718,7 +718,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.figure</parmname>
           </pt>
           <pd>common Bootstrap utility classes for DITA
@@ -726,7 +726,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.figure&#8203;.caption</parmname>
           </pt>
           <pd>
@@ -735,7 +735,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.figure&#8203;.image</parmname>
           </pt>
           <pd>
@@ -744,7 +744,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.footer</parmname>
           </pt>
           <pd>
@@ -753,7 +753,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.nav&#8203;.parent</parmname>
           </pt>
           <pd>
@@ -761,7 +761,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.pagination</parmname>
           </pt>
           <pd>
@@ -770,7 +770,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.section&#8203;.title</parmname>
           </pt>
           <pd>
@@ -779,7 +779,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.shortdesc</parmname>
           </pt>
           <pd>
@@ -788,7 +788,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.table</parmname>
           </pt>
           <pd>
@@ -797,7 +797,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.tabs</parmname>
           </pt>
           <pd>
@@ -806,7 +806,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.tabs&#8203;.vertical</parmname>
           </pt>
           <pd>
@@ -815,7 +815,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.thead</parmname>
           </pt>
           <pd>common Bootstrap utility classes for DITA
@@ -823,7 +823,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.css&#8203;.topic&#8203;.title</parmname>
           </pt>
           <pd>
@@ -849,9 +849,9 @@
       <indexterm><parmname>--bootstrap.icon.warning</parmname></indexterm>
       <p>The default Bootstrap icons used for DITA <xmlelement
         >note</xmlelement> elements can be overridden using additional command line parameters:</p>
-      <parml>
+      <parml otherprops="cols(4)">
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.note</parmname>
           </pt>
           <pd>
@@ -859,7 +859,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.attention</parmname>
           </pt>
           <pd>
@@ -867,7 +867,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.caution</parmname>
           </pt>
           <pd>
@@ -875,7 +875,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.danger</parmname>
           </pt>
           <pd>
@@ -883,7 +883,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.fastpath</parmname>
           </pt>
           <pd>
@@ -891,7 +891,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.important</parmname>
           </pt>
           <pd>
@@ -899,7 +899,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.notice</parmname>
           </pt>
           <pd>
@@ -907,7 +907,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.remember</parmname>
           </pt>
           <pd>
@@ -915,7 +915,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.restriction</parmname>
           </pt>
           <pd>
@@ -923,7 +923,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.tip</parmname>
           </pt>
           <pd>
@@ -931,7 +931,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.trouble</parmname>
           </pt>
           <pd>
@@ -939,7 +939,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bootstrap.icon&#8203;.warning</parmname>
           </pt>
           <pd>
@@ -964,9 +964,9 @@
           format="dita"
         >dark mode toggler</xref> are enabled by default, but for performance reasons they can be disabled by setting
         the following command line parameters to <option>no</option>:</p>
-      <parml>
+      <parml otherprops="cols(4)">
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--icons.include</parmname>
           </pt>
           <pd>enable Bootstrap
@@ -974,7 +974,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--popovers.include</parmname>
           </pt>
           <pd>
@@ -984,7 +984,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--dark.mode.include</parmname>
           </pt>
           <pd>
@@ -1000,7 +1000,7 @@
       <p>Opt-in breadcrumbs and menu bars and other modifiers can be added using the following parameters:</p>
       <parml>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--args.breadcrumbs</parmname>
           </pt>
           <pd>enable Bootstrap
@@ -1008,7 +1008,7 @@
         </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--menubar-toc.include</parmname>
           </pt>
           <pd>
@@ -1016,7 +1016,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--scrollspy-toc</parmname>
           </pt>
           <pd>
@@ -1024,7 +1024,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--bidi.include</parmname>
           </pt>
           <pd>
@@ -1033,7 +1033,7 @@
           </pd>
         </plentry>
         <plentry>
-          <pt outputclass="col-lg-4">
+          <pt>
             <parmname>--toc-spacer.padding</parmname>
           </pt>
           <pd>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -1018,19 +1018,23 @@
         </plentry>
         <plentry>
           <pt>
-            <parmname>--scrollspy-toc</parmname>
-          </pt>
-          <pd>
-            add a Bootstrap <xref href="./scrollspy.dita" format="dita">scrollspy</xref> navigator
-          </pd>
-        </plentry>
-        <plentry>
-          <pt>
             <parmname>--bidi.include</parmname>
           </pt>
           <pd>
             whether to force included support for
             <xref href="./rtl.dita" format="dita">RTL languages</xref>
+          </pd>
+        </plentry>
+      </parml>
+      <p>The following additional command line parameters are also available and described in more detail within
+        the documentation:</p>
+      <parml otherprops="cols(4)">
+        <plentry>
+          <pt>
+            <parmname>--scrollspy-toc</parmname>
+          </pt>
+          <pd>
+            add a Bootstrap <xref href="./scrollspy.dita" format="dita">scrollspy</xref> navigator
           </pd>
         </plentry>
         <plentry>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -998,7 +998,7 @@
         </plentry>
       </parml>
       <p>Opt-in breadcrumbs and menu bars and other modifiers can be added using the following parameters:</p>
-      <parml>
+      <parml otherprops="cols(4)">
         <plentry>
           <pt>
             <parmname>--args.breadcrumbs</parmname>

--- a/sample/typography.dita
+++ b/sample/typography.dita
@@ -18,6 +18,7 @@
         </indexterm>
         <indexterm><xmlatt>otherprops</xmlatt></indexterm>
         <indexterm><xmlelement>title</xmlelement></indexterm>
+        <indexterm><xmlelement>dl</xmlelement></indexterm>
       </keywords>
     </metadata>
   </prolog>
@@ -327,6 +328,41 @@
             inside your definition list.&lt;/dd&gt;
         &lt;/dlentry&gt;
       &lt;/dl&gt;
+    &lt;/dd&gt;
+  &lt;/dlentry&gt;
+&lt;/dl&gt;</codeblock>
+    <section>
+      <title outputclass="h3">Description list column width</title>
+      <p>Definitions lists use the twelve column system defined by the Bootstrap grid. By default each <xmlelement
+        >dt</xmlelement> spreads over 3 column widths and each <xmlelement
+        >dd</xmlelement> spreads over 9 column widths. Alter default width of terms by adding <xmlelement
+        >dl otherprops="cols(..)"</xmlelement></p>
+    </section>
+    <bodydiv outputclass="bd-example" deliveryTarget="html">
+      <dl otherprops="cols(2)">
+        <dlentry>
+          <dt>Description lists</dt>
+          <dd>A description list is perfect for defining terms.</dd>
+        </dlentry>
+        <dlentry>
+          <dt>Term</dt>
+          <dd>
+            <p>Definition for the term.</p>
+            <p>And some more placeholder definition text.</p>
+          </dd>
+        </dlentry>
+      </dl>
+    </bodydiv>
+    <codeblock>&lt;dl otherprops="cols(2)"&gt;
+  &lt;dlentry&gt;
+    &lt;dt&gt;Description lists&lt;/dt&gt;
+    &lt;dd&gt;A description list is perfect for defining terms.&lt;/dd&gt;
+  &lt;/dlentry&gt;
+  &lt;dlentry&gt;
+    &lt;dt&gt;Term&lt;/dt&gt;
+    &lt;dd&gt;
+      &lt;p&gt;Definition for the term.&lt;/p&gt;
+      &lt;p&gt;And some more placeholder definition text.&lt;/p&gt;
     &lt;/dd&gt;
   &lt;/dlentry&gt;
 &lt;/dl&gt;</codeblock>


### PR DESCRIPTION
The parameter list `<parml>` element contains a list of terms and definitions that describes the parameters in an application programming interface. 

Because a lot of the bootstrap params are quite long, I've overridden the breakpoint and added proper wrapping for mobile where necessary.

### Mobile

<img width="486" alt="Screenshot 2024-03-15 at 12 47 57" src="https://github.com/infotexture/dita-bootstrap/assets/3439249/da613987-3053-4ccd-a754-28d564e07af7">

### Web

![Screenshot 2024-03-15 at 12 46 28](https://github.com/infotexture/dita-bootstrap/assets/3439249/171160d7-75f0-45a9-ba06-536e957a0533)
