### PR TITLE
Use line feed character code in `$newline` variable

### DIFF
--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -44,11 +44,8 @@
     </xsl:apply-templates>
   </xsl:variable>
 
-  <!-- Define a newline character -->
-  <xsl:variable name="newline">
-<xsl:text>
-</xsl:text>
-  </xsl:variable>
+  <!-- Define a $newline variable that inserts a Unicode line feed character -->
+  <xsl:variable name="newline" select="'&#xa;'"/>
 
   <xsl:template name="bidi-auto-code">
     <!-- ↓ Ensure code is rendered LTR in RTL documents ↓ -->

--- a/Customization/xsl/topic.xsl
+++ b/Customization/xsl/topic.xsl
@@ -45,7 +45,7 @@
   </xsl:variable>
 
   <!-- Define a $newline variable that inserts a Unicode line feed character -->
-  <xsl:variable name="newline" select="'&#xa;'"/>
+  <xsl:variable name="newline" select="'&#xa;'" as="xs:string"/>
 
   <xsl:template name="bidi-auto-code">
     <!-- ↓ Ensure code is rendered LTR in RTL documents ↓ -->


### PR DESCRIPTION
Explicitly insert the Unicode hex character code `&#xa;` for the Line Feed (LF) character instead of relying on the line break in the `<xsl:text>` element.

_(This approach is more resilient if the XSL source file is inadvertently re-formatted or re-indented.)_

As suggested by @stefan-jung in https://github.com/prettier/plugin-xml/issues/748#issuecomment-2009601555. 🙇 
