### PR TITLE
Prepare 5.3.6 release

### DIFF
--- a/.github/dita-ot/header.xml
+++ b/.github/dita-ot/header.xml
@@ -181,7 +181,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
               >
                 Default
               </button>
@@ -193,7 +193,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/cerulean/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/cerulean/bootstrap.min.css"
               >
                 Cerulean
               </button>
@@ -202,7 +202,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/cosmo/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/cosmo/bootstrap.min.css"
               >
                 Cosmo
               </button>
@@ -211,7 +211,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/cyborg/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/cyborg/bootstrap.min.css"
               >
                 Cyborg
               </button>
@@ -220,7 +220,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/darkly/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/darkly/bootstrap.min.css"
               >
                 Darkly
               </button>
@@ -229,7 +229,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/flatly/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/flatly/bootstrap.min.css"
               >
                 Flatly
               </button>
@@ -238,7 +238,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/journal/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/journal/bootstrap.min.css"
               >
                 Journal
               </button>
@@ -247,7 +247,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/litera/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/litera/bootstrap.min.css"
               >
                 Litera
               </button>
@@ -256,7 +256,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/lumen/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/lumen/bootstrap.min.css"
               >
                 Lumen
               </button>
@@ -265,7 +265,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/lux/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/lux/bootstrap.min.css"
               >
                 Lux
               </button>
@@ -274,7 +274,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/materia/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/materia/bootstrap.min.css"
               >
                 Materia
               </button>
@@ -283,7 +283,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/minty/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/minty/bootstrap.min.css"
               >
                 Minty
               </button>
@@ -292,7 +292,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/morph/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/morph/bootstrap.min.css"
               >
                 Morph
               </button>
@@ -302,7 +302,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/pulse/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/pulse/bootstrap.min.css"
               >
                 Pulse
               </button>
@@ -311,7 +311,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/quartz/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/quartz/bootstrap.min.css"
               >
                 Quartz
               </button>
@@ -320,7 +320,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/sandstone/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/sandstone/bootstrap.min.css"
               >
                 Sandstone
               </button>
@@ -329,7 +329,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/simplex/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/simplex/bootstrap.min.css"
               >
                 Simplex
               </button>
@@ -338,7 +338,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/sketchy/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/sketchy/bootstrap.min.css"
               >
                 Sketchy
               </button>
@@ -347,7 +347,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/slate/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/slate/bootstrap.min.css"
               >
                 Slate
               </button>
@@ -356,7 +356,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/solar/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/solar/bootstrap.min.css"
               >
                 Solar
               </button>
@@ -365,7 +365,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/spacelab/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/spacelab/bootstrap.min.css"
               >
                 SpaceLab
               </button>
@@ -374,7 +374,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/superhero/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/superhero/bootstrap.min.css"
               >
                 Superhero
               </button>
@@ -383,7 +383,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/united/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/united/bootstrap.min.css"
               >
                 United
               </button>
@@ -392,7 +392,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/vapor/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/vapor/bootstrap.min.css"
               >
                 Vapor
               </button>
@@ -401,7 +401,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/yeti/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/yeti/bootstrap.min.css"
               >
                 Yeti
               </button>
@@ -410,7 +410,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/zephyr/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/zephyr/bootstrap.min.css"
               >
                 Zephyr
               </button>

--- a/includes/bootstrap.hdf.rtl.xml
+++ b/includes/bootstrap.hdf.rtl.xml
@@ -1,13 +1,13 @@
 <div>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.rtl.min.css"
-    integrity="sha384-q8+l9TmX3RaSz3HKGBmqP2u5MkgeN7HrfOJBLcTgZsQsbrx8WqqxdA5PuwUV9WIx"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.rtl.min.css"
+    integrity="sha384-MdqCcafa5BLgxBDJ3d/4D292geNL64JyRtSGjEszRUQX9rhL1QkcnId+OT7Yw+D+"
     crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/bootstrap.hdf.xml
+++ b/includes/bootstrap.hdf.xml
@@ -1,13 +1,13 @@
 <div>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css"
-    integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
+    integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT"
     crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/script-only.hdf.xml
+++ b/includes/script-only.hdf.xml
@@ -1,7 +1,7 @@
 <div>
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/theme.hdf.xml
+++ b/includes/theme.hdf.xml
@@ -1,11 +1,11 @@
 <div>
   <link
-    href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.5/dist/@@theme@@"
+    href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/@@theme@@"
     rel="stylesheet"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
     crossorigin="anonymous"
   />
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@prettier/plugin-xml": "3.4.1",
-        "bootstrap": "^5.3.5",
-        "bootstrap-icons": "^1.11.3",
-        "bootswatch": "^5.3.5",
+        "bootstrap": "^5.3.6",
+        "bootstrap-icons": "^1.13.1",
+        "bootswatch": "^5.3.6",
         "lefthook": "^1.11.13",
         "prettier": "3.5.3",
         "stylelint": "^16.19.1",
@@ -449,9 +449,9 @@
       ]
     },
     "node_modules/bootstrap": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.5.tgz",
-      "integrity": "sha512-ct1CHKtiobRimyGzmsSldEtM03E8fcEX4Tb3dGXz1V8faRwM50+vfHwTzOxB3IlKO7m+9vTH3s/3C6T2EAPeTA==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
+      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
       "dev": true,
       "funding": [
         {
@@ -463,14 +463,15 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/bootstrap-icons": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
-      "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+      "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
       "dev": true,
       "funding": [
         {
@@ -481,13 +482,15 @@
           "type": "opencollective",
           "url": "https://opencollective.com/bootstrap"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/bootswatch": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-5.3.5.tgz",
-      "integrity": "sha512-1z8LNoUL5NHmv/hNROALQ6qtjw9OJIjMgP8ovBlIft+oI15b/mvnzxGL896iO9LtoDZH0Vdm+D2YW+j03GduSg==",
-      "dev": true
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-5.3.6.tgz",
+      "integrity": "sha512-d2Kwu5IaALz9gb7fmW20mXU4oCJqBrXmJ3ffk8bZPIOMohJOt0/549liK2Jp9zalkxg30dZ+1wf4OH2m1lJC9w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/braces": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   },
   "devDependencies": {
     "@prettier/plugin-xml": "3.4.1",
-    "bootstrap": "^5.3.5",
-    "bootstrap-icons": "^1.11.3",
-    "bootswatch": "^5.3.5",
+    "bootstrap": "^5.3.6",
+    "bootstrap-icons": "^1.13.1",
+    "bootswatch": "^5.3.6",
     "lefthook": "^1.11.13",
     "prettier": "3.5.3",
     "stylelint": "^16.19.1",

--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <!-- Copyright © 2017 · infotexture · Roger W. Fienhold Sheen -->
 <!-- See the accompanying LICENSE file for applicable license -->
 <plugin id="net.infotexture.dita-bootstrap">
-  <feature extension="package.version" value="5.3.5.1"/>
+  <feature extension="package.version" value="5.3.6"/>
   <require plugin="org.dita.html5"/>
   <require plugin="fox.jason.extend.css"/>
   <!-- extension points -->


### PR DESCRIPTION
Includes changes from 366de71:

- [x] Update Bootstrap to [5.3.6](https://blog.getbootstrap.com/2025/05/05/bootstrap-5-3-6/)
- [x] Update [Bootstrap Icons](https://icons.getbootstrap.com) to [1.13.1](https://blog.getbootstrap.com/2025/05/09/bootstrap-icons-1-12-1-13/)
- [x] Bump Bootswatch themes to [5.3.6](https://github.com/thomaspark/bootswatch/compare/v5.3.5...v5.3.6)