### PR TITLE
Update Dependencies Again

### DIFF
--- a/.github/dita-ot/header.xml
+++ b/.github/dita-ot/header.xml
@@ -181,7 +181,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
               >
                 Default
               </button>
@@ -193,7 +193,16 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/cerulean/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/brite/bootstrap.min.css"
+              >
+                Brite
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="dropdown-item d-flex align-items-center"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/cerulean/bootstrap.min.css"
               >
                 Cerulean
               </button>
@@ -202,7 +211,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/cosmo/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/cosmo/bootstrap.min.css"
               >
                 Cosmo
               </button>
@@ -211,7 +220,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/cyborg/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/cyborg/bootstrap.min.css"
               >
                 Cyborg
               </button>
@@ -220,7 +229,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/darkly/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/darkly/bootstrap.min.css"
               >
                 Darkly
               </button>
@@ -229,7 +238,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/flatly/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/flatly/bootstrap.min.css"
               >
                 Flatly
               </button>
@@ -238,7 +247,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/journal/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/journal/bootstrap.min.css"
               >
                 Journal
               </button>
@@ -247,7 +256,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/litera/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/litera/bootstrap.min.css"
               >
                 Litera
               </button>
@@ -256,7 +265,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/lumen/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/lumen/bootstrap.min.css"
               >
                 Lumen
               </button>
@@ -265,7 +274,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/lux/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/lux/bootstrap.min.css"
               >
                 Lux
               </button>
@@ -274,7 +283,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/materia/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/materia/bootstrap.min.css"
               >
                 Materia
               </button>
@@ -283,7 +292,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/minty/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/minty/bootstrap.min.css"
               >
                 Minty
               </button>
@@ -292,7 +301,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/morph/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/morph/bootstrap.min.css"
               >
                 Morph
               </button>
@@ -302,7 +311,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/pulse/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/pulse/bootstrap.min.css"
               >
                 Pulse
               </button>
@@ -311,7 +320,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/quartz/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/quartz/bootstrap.min.css"
               >
                 Quartz
               </button>
@@ -320,7 +329,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/sandstone/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/sandstone/bootstrap.min.css"
               >
                 Sandstone
               </button>
@@ -329,7 +338,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/simplex/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/simplex/bootstrap.min.css"
               >
                 Simplex
               </button>
@@ -338,7 +347,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/sketchy/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/sketchy/bootstrap.min.css"
               >
                 Sketchy
               </button>
@@ -347,7 +356,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/slate/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/slate/bootstrap.min.css"
               >
                 Slate
               </button>
@@ -356,7 +365,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/solar/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/solar/bootstrap.min.css"
               >
                 Solar
               </button>
@@ -365,7 +374,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/spacelab/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/spacelab/bootstrap.min.css"
               >
                 SpaceLab
               </button>
@@ -374,7 +383,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/superhero/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/superhero/bootstrap.min.css"
               >
                 Superhero
               </button>
@@ -383,7 +392,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/united/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/united/bootstrap.min.css"
               >
                 United
               </button>
@@ -392,7 +401,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/vapor/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/vapor/bootstrap.min.css"
               >
                 Vapor
               </button>
@@ -401,7 +410,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/yeti/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/yeti/bootstrap.min.css"
               >
                 Yeti
               </button>
@@ -410,7 +419,7 @@
               <button
                 type="button"
                 class="dropdown-item d-flex align-items-center"
-                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/zephyr/bootstrap.min.css"
+                data-bs-css-href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/zephyr/bootstrap.min.css"
               >
                 Zephyr
               </button>

--- a/includes/bootstrap.hdf.rtl.xml
+++ b/includes/bootstrap.hdf.rtl.xml
@@ -1,13 +1,13 @@
 <div>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.rtl.min.css"
-    integrity="sha384-MdqCcafa5BLgxBDJ3d/4D292geNL64JyRtSGjEszRUQX9rhL1QkcnId+OT7Yw+D+"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.rtl.min.css"
+    integrity="sha384-CfCrinSRH2IR6a4e6fy2q6ioOX7O6Mtm1L9vRvFZ1trBncWmMePhzvafv7oIcWiW"
     crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/bootstrap.hdf.xml
+++ b/includes/bootstrap.hdf.xml
@@ -1,13 +1,13 @@
 <div>
   <link
     rel="stylesheet"
-    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/css/bootstrap.min.css"
-    integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT"
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
     crossorigin="anonymous"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/bootstrap.icons.hdf.xml
+++ b/includes/bootstrap.icons.hdf.xml
@@ -1,6 +1,6 @@
 <link
   rel="stylesheet"
-  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
-  integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+"
+  href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css"
+  integrity="sha384-CK2SzKma4jA5H/MXDUU7i1TqZlCFaD4T01vtyDFvPlD97JQyS+IsSh1nI2EFbp"
   crossorigin="anonymous"
 />

--- a/includes/script-only.hdf.xml
+++ b/includes/script-only.hdf.xml
@@ -1,7 +1,7 @@
 <div>
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
     crossorigin="anonymous"
   />
 </div>

--- a/includes/theme.hdf.xml
+++ b/includes/theme.hdf.xml
@@ -1,11 +1,11 @@
 <div>
   <link
-    href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.6/dist/@@theme@@"
+    href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.7/dist/@@theme@@"
     rel="stylesheet"
   />
   <script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
+    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+    integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
     crossorigin="anonymous"
   />
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,9 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@prettier/plugin-xml": "3.4.2",
-        "bootstrap": "^5.3.6",
+        "bootstrap": "^5.3.8",
         "bootstrap-icons": "^1.13.1",
-        "bootswatch": "^5.3.6",
+        "bootswatch": "^5.3.7",
         "lefthook": "^1.12.3",
         "prettier": "3.6.2",
         "stylelint": "^16.23.1",
@@ -430,9 +430,9 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.6.tgz",
-      "integrity": "sha512-jX0GAcRzvdwISuvArXn3m7KZscWWFAf1MKBcnzaN02qWMb3jpMoUX4/qgeiGzqyIb4ojulRzs89UCUmGcFSzTA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "dev": true,
       "funding": [
         {
@@ -444,7 +444,6 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
-      "license": "MIT",
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
@@ -467,11 +466,10 @@
       "license": "MIT"
     },
     "node_modules/bootswatch": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-5.3.6.tgz",
-      "integrity": "sha512-d2Kwu5IaALz9gb7fmW20mXU4oCJqBrXmJ3ffk8bZPIOMohJOt0/549liK2Jp9zalkxg30dZ+1wf4OH2m1lJC9w==",
-      "dev": true,
-      "license": "MIT"
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/bootswatch/-/bootswatch-5.3.7.tgz",
+      "integrity": "sha512-n0X99+Jmpmd4vgkli5KwMOuAkgdyUPhq7cIAwoGXbM6WhE/mmkWACfxpr7WZeG9Pdx509Ndi+2K1HlzXXOr8/Q==",
+      "dev": true
     },
     "node_modules/braces": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
   },
   "devDependencies": {
     "@prettier/plugin-xml": "3.4.2",
-    "bootstrap": "^5.3.6",
+    "bootstrap": "^5.3.8",
     "bootstrap-icons": "^1.13.1",
-    "bootswatch": "^5.3.6",
+    "bootswatch": "^5.3.7",
     "lefthook": "^1.12.3",
     "prettier": "3.6.2",
     "stylelint": "^16.23.1",

--- a/plugin.xml
+++ b/plugin.xml
@@ -312,6 +312,7 @@
       desc="Defines a specific custom bootstrap theme to use"
       type="enum"
     >
+      <val>brite</val>
       <val>cerulean</val>
       <val>cosmo</val>
       <val>cyborg</val>

--- a/sample/alerts.dita
+++ b/sample/alerts.dita
@@ -33,14 +33,14 @@
           <codeph>alert-success</codeph>).</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
-      <section outputclass="alert-primary">A simple primary alert—check it out! </section>
-      <section outputclass="alert-secondary">A simple secondary alert—check it out! </section>
-      <section outputclass="alert-success">A simple success alert—check it out! </section>
-      <section outputclass="alert-danger">A simple danger alert—check it out! </section>
-      <section outputclass="alert-warning">A simple warning alert—check it out! </section>
-      <section outputclass="alert-info">A simple info alert—check it out! </section>
-      <section outputclass="alert-light">A simple light alert—check it out! </section>
-      <section outputclass="alert-dark">A simple dark alert—check it out! </section>
+      <section outputclass="alert-primary">A simple primary alert—check it out!</section>
+      <section outputclass="alert-secondary">A simple secondary alert—check it out!</section>
+      <section outputclass="alert-success">A simple success alert—check it out!</section>
+      <section outputclass="alert-danger">A simple danger alert—check it out!</section>
+      <section outputclass="alert-warning">A simple warning alert—check it out!</section>
+      <section outputclass="alert-info">A simple info alert—check it out!</section>
+      <section outputclass="alert-light">A simple light alert—check it out!</section>
+      <section outputclass="alert-dark">A simple dark alert—check it out!</section>
     </bodydiv>
     <codeblock>&lt;section outputclass="alert-primary"&gt;
   A simple primary alert—check it out!
@@ -106,7 +106,7 @@
       <note type="caution">Care is required when proceeding.</note>
       <note type="important">This note is important.</note>
       <note type="restriction">You can't do what this note says.</note>
-      <note type="danger">You may hurt yourself! </note>
+      <note type="danger">You may hurt yourself!</note>
       <note type="other" othertype="Another note">This is something other than a normal note.</note>
     </div>
     <codeblock>&lt;note type="note"&gt;This is just a note.&lt;/note&gt;

--- a/sample/images.dita
+++ b/sample/images.dita
@@ -90,8 +90,8 @@
       image MIME type. The final <xmlelement>image</xmlelement> is the default.</p>
     </section>
     <bodydiv outputclass="bd-example" deliveryTarget="html">
-       <p>Change the width of the browser to view different images:</p>
-       <div outputclass="d-picture" deliveryTarget="html">
+      <p>Change the width of the browser to view different images:</p>
+      <div outputclass="d-picture" deliveryTarget="html">
         <image otherprops="media(min-width: 700px)" scope="external" href="https://picsum.photos/id/1/800/400"/>
         <image otherprops="media(min-width: 450px)" scope="external" href="https://picsum.photos/id/4/400/200"/>
         <image otherprops="type(image/jpeg)" scope="external" href="https://picsum.photos/id/5/200/200.jpg"/>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -72,7 +72,7 @@
      <parmname>--args.hdr</parmname>=<filepath>path/to/your-header.xml</filepath> \
      <parmname>--bootstrap.theme</parmname>=<option>&lt;theme-name&gt;</option></codeblock>
 
-     <ol outputclass="carousel pt-2" deliveryTarget="html" otherprops="indicators(true)">
+      <ol outputclass="carousel pt-2" deliveryTarget="html" otherprops="indicators(true)">
         <li>
           <div>
             <div outputclass="col-4">
@@ -163,7 +163,7 @@
             </div>
           </div>
         </li>
-         <li>
+        <li>
           <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
@@ -249,7 +249,7 @@
             </div>
           </div>
         </li>
-         <li>
+        <li>
           <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
@@ -339,7 +339,7 @@
             </div>
           </div>
         </li>
-         <li>
+        <li>
           <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -80,6 +80,23 @@
                 <image
                   outputclass="card-img-top"
                   scope="external"
+                  href="https://bootswatch.com/brite/thumbnail.png"
+                />
+                <p outputclass="text-center">
+                  <xref
+                    outputclass="link stretched-link link-underline link-underline-opacity-0"
+                    href="https://bootswatch.com/brite/"
+                    format="html"
+                    scope="external"
+                  ><option>brite</option></xref>
+                </p>
+              </div>
+            </div>
+            <div outputclass="col-4">
+              <div outputclass="card w-100">
+                <image
+                  outputclass="card-img-top"
+                  scope="external"
                   href="https://bootswatch.com/cerulean/thumbnail.png"
                 />
                 <p outputclass="text-center">
@@ -105,6 +122,10 @@
                 </p>
               </div>
             </div>
+          </div>
+        </li>
+        <li>
+          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/cyborg/thumbnail.png"/>
@@ -118,10 +139,6 @@
                 </p>
               </div>
             </div>
-          </div>
-        </li>
-        <li>
-          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/darkly/thumbnail.png"/>
@@ -148,6 +165,10 @@
                 </p>
               </div>
             </div>
+          </div>
+        </li>
+         <li>
+          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/journal/thumbnail.png"/>
@@ -161,10 +182,6 @@
                 </p>
               </div>
             </div>
-          </div>
-        </li>
-         <li>
-          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/litera/thumbnail.png"/>
@@ -191,6 +208,10 @@
                 </p>
               </div>
             </div>
+          </div>
+        </li>
+        <li>
+          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/lux/thumbnail.png"/>
@@ -204,10 +225,6 @@
                 </p>
               </div>
             </div>
-          </div>
-        </li>
-        <li>
-          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/materia/thumbnail.png"/>
@@ -234,6 +251,10 @@
                 </p>
               </div>
             </div>
+          </div>
+        </li>
+         <li>
+          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/morph/thumbnail.png"/>
@@ -247,10 +268,6 @@
                 </p>
               </div>
             </div>
-          </div>
-        </li>
-         <li>
-          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/pulse/thumbnail.png"/>
@@ -277,6 +294,10 @@
                 </p>
               </div>
             </div>
+          </div>
+        </li>
+        <li>
+          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image
@@ -294,10 +315,6 @@
                 </p>
               </div>
             </div>
-          </div>
-        </li>
-        <li>
-          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/simplex/thumbnail.png"/>
@@ -324,6 +341,10 @@
                 </p>
               </div>
             </div>
+          </div>
+        </li>
+         <li>
+          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/slate/thumbnail.png"/>
@@ -337,10 +358,6 @@
                 </p>
               </div>
             </div>
-          </div>
-        </li>
-         <li>
-          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/solar/thumbnail.png"/>
@@ -371,6 +388,10 @@
                 </p>
               </div>
             </div>
+          </div>
+        </li>
+        <li>
+          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image
@@ -388,10 +409,6 @@
                 </p>
               </div>
             </div>
-          </div>
-        </li>
-        <li>
-          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/united/thumbnail.png"/>
@@ -418,6 +435,10 @@
                 </p>
               </div>
             </div>
+          </div>
+        </li>
+        <li>
+          <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
                 <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/yeti/thumbnail.png"/>

--- a/sample/index.dita
+++ b/sample/index.dita
@@ -77,11 +77,7 @@
           <div>
             <div outputclass="col-4">
               <div outputclass="card w-100">
-                <image
-                  outputclass="card-img-top"
-                  scope="external"
-                  href="https://bootswatch.com/brite/thumbnail.png"
-                />
+                <image outputclass="card-img-top" scope="external" href="https://bootswatch.com/brite/thumbnail.png"/>
                 <p outputclass="text-center">
                   <xref
                     outputclass="link stretched-link link-underline link-underline-opacity-0"

--- a/sample/nav.dita
+++ b/sample/nav.dita
@@ -25,7 +25,7 @@
     </metadata>
   </prolog>
   <body outputclass="language-markup">
-   <section>
+    <section>
       <title>Sidebar</title>
       <p>The plug-in extends the standard HTML5 table of contents (ToC)
         <xref

--- a/sample/offline.dita
+++ b/sample/offline.dita
@@ -87,7 +87,7 @@
             <title>Sample <filepath>offline-bootstrap.css</filepath> file</title>
             <codeblock outputclass="language-css">@charset "UTF-8";
 /*!
- * Bootstrap  v5.3.0 (https://getbootstrap.com/)
+ * Bootstrap v5.3.0 (https://getbootstrap.com/)
  * Copyright 2011-2023 The Bootstrap Authors
  * Licensed under MIT (https://github.com/twbs/bootstrap/blob/main/LICENSE)
  */

--- a/sample/search-box.dita
+++ b/sample/search-box.dita
@@ -52,13 +52,13 @@
     </section>
 
     <section id="installing-node.js">
-        <title>Installing Node.js</title>
-        <p>
-          The <term>DITA Bootstrap Lunr Search</term> plug-in uses the <xref
-          href="https://nodejs.org/"
-          format="html"
-          scope="external"
-        >Node.js</xref> JavaScript runtime to generate the Lunr.js search index.
+      <title>Installing Node.js</title>
+      <p>
+        The
+        <term>DITA Bootstrap Lunr Search</term>
+        plug-in uses the
+        <xref href="https://nodejs.org/" format="html" scope="external">Node.js</xref>
+        JavaScript runtime to generate the Lunr.js search index.
         Node.js must therefore be present for the index to be generated successfully.
         </p>
         <p>

--- a/sample/tables.dita
+++ b/sample/tables.dita
@@ -102,7 +102,7 @@
               <entry>Cell</entry>
             </row>
             <row outputclass="table-secondary">
-              <entry>Secondary </entry>
+              <entry>Secondary</entry>
               <entry>Cell</entry>
               <entry>Cell</entry>
             </row>

--- a/sample/tooltips.dita
+++ b/sample/tooltips.dita
@@ -28,7 +28,7 @@
   <body outputclass="language-markup">
     <section>
       <title>Overview</title>
-      <p>Things to know when using the tooltip plugin: </p>
+      <p>Things to know when using the tooltip plugin:</p>
       <ul>
         <li>Tooltips rely on the third-party library
           <xref href="https://popper.js.org" format="html" scope="external">Popper</xref> for positioning.</li>


### PR DESCRIPTION
> Bootstrap v5.3.8 is out with a reversion for a dropdown focus bug, some CSS updates, 
> and several docs updates. The plan is for this to be the last patch release before v5.4.0 drops.

see [here](https://blog.getbootstrap.com/2025/08/25/bootstrap-5-3-8/)

- Bump Bootstrap to 5.3.8
- Bump Bootswatch to 5.3.7
- Bump Icons to 1.13.1
- Add `brite` Bootswatch theme

This will also close #263 and #256