### PR TITLE
Fix #271: Update Bootstrap Icons integrity hash

### DIFF
--- a/includes/bootstrap.icons.hdf.xml
+++ b/includes/bootstrap.icons.hdf.xml
@@ -1,6 +1,6 @@
 <link
   rel="stylesheet"
   href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css"
-  integrity="sha384-CK2SzKma4jA5H/MXDUU7i1TqZlCFaD4T01vtyDFvPlD97JQyS+IsSh1nI2EFbp"
+  integrity="sha384-CK2SzKma4jA5H/MXDUU7i1TqZlCFaD4T01vtyDFvPlD97JQyS+IsSh1nI2EFbpyk"
   crossorigin="anonymous"
 />


### PR DESCRIPTION
- Get correct hash value from https://www.srihash.org
- Amends 9d36a6f
- Fixes #271