### PR TITLE
Prepare 5.3.8 release

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -3,7 +3,7 @@
 <!-- Copyright © 2017 · infotexture · Roger W. Fienhold Sheen -->
 <!-- See the accompanying LICENSE file for applicable license -->
 <plugin id="net.infotexture.dita-bootstrap">
-  <feature extension="package.version" value="5.3.6"/>
+  <feature extension="package.version" value="5.3.8"/>
   <require plugin="org.dita.html5"/>
   <require plugin="fox.jason.extend.css"/>
   <!-- extension points -->


### PR DESCRIPTION
Package recent changes for 5.3.8 release:

- [x] Update Bootstrap to [5.3.8](https://blog.getbootstrap.com/2025/08/25/bootstrap-5-3-8/)
- [x] Update [Bootstrap Icons](https://icons.getbootstrap.com) to [1.13.1](https://blog.getbootstrap.com/2025/05/09/bootstrap-icons-1-12-1-13/)
- [x] Bump Bootswatch themes to [5.3.8](https://github.com/thomaspark/bootswatch/compare/v5.3.6...v5.3.8)

> **Note**
> This PR is a draft to summarize the changes for the [5.3.8](https://github.com/infotexture/dita-bootstrap/milestone/11) milestone. There's no need to merge it in the GitHub UI. It will be merged automatically via Git Flow to ensure the tag is created correctly and merged into each of the base branches.
